### PR TITLE
fix: use deploy.resources for GPU in docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,20 @@ docker run -d \
 
 Save the appropriate file as `~/cvbench/docker-compose.yml` and run `docker compose up -d`.
 
-**With GPU** (`runtime: nvidia` requires NVIDIA Container Toolkit):
+**With GPU** (requires [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)):
 
 ```yaml
 services:
   cvbench:
     image: mmgalushka/cvbench:latest   # pin a release: mmgalushka/cvbench:0.2.0
     container_name: cvbench
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     ports:
       - "0.0.0.0:8888:8888"
       - "0.0.0.0:6006:6006"


### PR DESCRIPTION
Replace deprecated `runtime: nvidia` with the `deploy.resources.reservations.devices` approach in the README Docker Compose GPU example.

The old `runtime: nvidia` key fails with `unknown or invalid runtime name: nvidia` on systems where the NVIDIA Container Toolkit is not registered as a Docker runtime. The `deploy` syntax works with the standard NVIDIA Container Toolkit setup and is the recommended approach.

Closes #3