### PR TITLE
fix: add tokenizers as explicit dependency to resolve keras_hub import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "tensorflow",
     "keras",
     "keras-hub",
+    "tokenizers",
     "click",
     "pyyaml",
     "scikit-learn",


### PR DESCRIPTION
## Summary
- `keras_hub` requires the HuggingFace `tokenizers` library but does not always declare it as a hard dependency
- This caused a `ModuleNotFoundError: No module named 'tokenizers'` at import time, preventing the `train` command from starting
- Added `tokenizers` as an explicit dependency in `pyproject.toml`

## Test plan
- [ ] Rebuild the Docker image
- [ ] Run `train <data_dir>` and confirm no import error on startup

Closes #4