### PR TITLE
fix: add sentencepiece as explicit dependency to resolve keras_hub import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "keras",
     "keras-hub",
     "tokenizers",
+    "sentencepiece",
     "click",
     "pyyaml",
     "scikit-learn",


### PR DESCRIPTION
## Summary
- `keras_hub` imports `sentencepiece` unconditionally in its tokenizer module but does not declare it as a required dependency
- This caused `ModuleNotFoundError: No module named 'sentencepiece'` at import time, preventing the `train` command from starting
- Added `sentencepiece` as an explicit dependency in `pyproject.toml`

## Test plan
- [x] Rebuild the Docker image
- [x] Run `train <data_dir>` and confirm no import error on startup

Closes #8