### PR TITLE
feat: add progress bar, GPU/CPU status, and suppress TF logs in evaluate and train

### DIFF
--- a/cli/evaluate.py
+++ b/cli/evaluate.py
@@ -1,7 +1,10 @@
 import contextlib
 import io
+import os
 import warnings
 from pathlib import Path
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 
 import click
 import keras
@@ -24,6 +27,11 @@ def evaluate(run_dir, output_dir):
 
     n_test = sum(1 for _ in Path(cfg.data.test_dir).glob("*/*"))
     print(f" Found {n_test} files for evaluation ({len(class_names)} classes).")
+
+    import tensorflow as tf
+    tf.get_logger().setLevel("ERROR")
+    import absl.logging
+    absl.logging.set_verbosity(absl.logging.ERROR)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Skipping variable loading for optimizer")

--- a/cli/evaluate.py
+++ b/cli/evaluate.py
@@ -19,6 +19,18 @@ from core import evaluator as _evaluator
 @click.option("--output-dir", default=None, help="Where to write eval outputs (default: run_dir).")
 def evaluate(run_dir, output_dir):
     """Evaluate a trained model in RUN_DIR on the held-out test split."""
+    import tensorflow as tf
+    tf.get_logger().setLevel("ERROR")
+    import absl.logging
+    absl.logging.set_verbosity(absl.logging.ERROR)
+
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        names = ", ".join(g.name for g in gpus)
+        print(f"\033[92m🟢 GPU      : {len(gpus)} device(s) — {names}\033[0m")
+    else:
+        print(f"\033[93m⚠️  GPU      : not available — evaluating on CPU\033[0m")
+
     cfg = load_config(run_dir)
 
     class_names = get_class_names(cfg.data.train_dir)
@@ -27,11 +39,6 @@ def evaluate(run_dir, output_dir):
 
     n_test = sum(1 for _ in Path(cfg.data.test_dir).glob("*/*"))
     print(f" Found {n_test} files for evaluation ({len(class_names)} classes).")
-
-    import tensorflow as tf
-    tf.get_logger().setLevel("ERROR")
-    import absl.logging
-    absl.logging.set_verbosity(absl.logging.ERROR)
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Skipping variable loading for optimizer")

--- a/cli/train.py
+++ b/cli/train.py
@@ -64,6 +64,14 @@ def train(
     """
     from datetime import date
 
+    import tensorflow as tf
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        names = ", ".join(g.name for g in gpus)
+        print(f"\033[92m🟢 GPU      : {len(gpus)} device(s) — {names}\033[0m")
+    else:
+        print(f"\033[93m⚠️  GPU      : not available — training on CPU\033[0m")
+
     class_weight_cfg = _parse_class_weight(class_weight_raw)
 
     cfg = build_config(

--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -8,20 +8,6 @@ import numpy as np
 import tqdm
 
 
-_GREEN = "\033[92m"
-_YELLOW = "\033[93m"
-_RESET = "\033[0m"
-
-
-def _device_status_line() -> str:
-    """Return a coloured GPU/CPU availability line for the evaluation header."""
-    import tensorflow as tf
-    gpus = tf.config.list_physical_devices("GPU")
-    if gpus:
-        names = ", ".join(g.name for g in gpus)
-        return f"{_GREEN}🟢 GPU      : {len(gpus)} device(s) — {names}{_RESET}"
-    return f"{_YELLOW}⚠️  GPU      : not available — evaluating on CPU{_RESET}"
-
 
 def evaluate(
     model: keras.Model,
@@ -133,7 +119,6 @@ def _print_report(report: dict, class_names: list[str], run_dir: str, out_dir: P
     print("━" * w)
     print(f" CVBench — evaluate  |  run: {run_name}")
     print("━" * w)
-    print(f" {_device_status_line()}")
     print(f" Split             : test")
     print(f" Images evaluated  : {report['n_images']}")
     print(f" Overall accuracy  : {report['overall_accuracy'] * 100:.1f}%")

--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -5,6 +5,22 @@ from pathlib import Path
 
 import keras
 import numpy as np
+import tqdm
+
+
+_GREEN = "\033[92m"
+_YELLOW = "\033[93m"
+_RESET = "\033[0m"
+
+
+def _device_status_line() -> str:
+    """Return a coloured GPU/CPU availability line for the evaluation header."""
+    import tensorflow as tf
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        names = ", ".join(g.name for g in gpus)
+        return f"{_GREEN}🟢 GPU      : {len(gpus)} device(s) — {names}{_RESET}"
+    return f"{_YELLOW}⚠️  GPU      : not available — evaluating on CPU{_RESET}"
 
 
 def evaluate(
@@ -21,10 +37,14 @@ def evaluate(
     out_dir = Path(output_dir or run_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # Collect predictions and ground truth
-    y_true, y_pred = [], []
-    for images, labels in test_ds:
+    # Single pass: collect predictions, ground truth, and raw scores for top-3
+    n_batches = test_ds.cardinality().numpy()
+    total = int(n_batches) if n_batches > 0 else None
+
+    y_true, y_pred, all_preds = [], [], []
+    for images, labels in tqdm.tqdm(test_ds, total=total, desc=" Evaluating", unit="batch"):
         preds = model.predict(images, verbose=0)
+        all_preds.append(preds)
         y_pred.extend(np.argmax(preds, axis=1))
         y_true.extend(np.argmax(labels.numpy(), axis=1))
 
@@ -34,15 +54,12 @@ def evaluate(
     n = len(y_true)
     overall_acc = float(np.mean(y_true == y_pred))
 
-    # Top-3 accuracy (if num_classes >= 3)
+    # Top-3 accuracy (if num_classes >= 3) — reuse already-collected scores
     top3_acc = None
     if model.output_shape[-1] >= 3:
-        all_preds = []
-        for images, _ in test_ds:
-            all_preds.append(model.predict(images, verbose=0))
-        all_preds = np.concatenate(all_preds, axis=0)
-        top3 = np.argsort(all_preds, axis=1)[:, -3:]
-        top3_acc = float(np.mean([y_true[i] in top3[i] for i in range(len(y_true))]))
+        all_preds_np = np.concatenate(all_preds, axis=0)
+        top3 = np.argsort(all_preds_np, axis=1)[:, -3:]
+        top3_acc = float(np.mean([y_true[i] in top3[i] for i in range(n)]))
 
     # Per-class P / R / F1
     per_class = {}
@@ -116,6 +133,7 @@ def _print_report(report: dict, class_names: list[str], run_dir: str, out_dir: P
     print("━" * w)
     print(f" CVBench — evaluate  |  run: {run_name}")
     print("━" * w)
+    print(f" {_device_status_line()}")
     print(f" Split             : test")
     print(f" Images evaluated  : {report['n_images']}")
     print(f" Overall accuracy  : {report['overall_accuracy'] * 100:.1f}%")

--- a/core/trainer.py
+++ b/core/trainer.py
@@ -9,21 +9,6 @@ from core.checkpoint import build_checkpoint_callback, prune_checkpoints
 from core.config import CVBenchConfig, update_run_status
 
 
-_GREEN = "\033[92m"
-_YELLOW = "\033[93m"
-_RESET = "\033[0m"
-
-
-def _gpu_status_line() -> str:
-    """Return a coloured GPU availability line for the training header."""
-    import tensorflow as tf
-    gpus = tf.config.list_physical_devices("GPU")
-    if gpus:
-        names = ", ".join(g.name for g in gpus)
-        return f"{_GREEN}🟢 GPU      : {len(gpus)} device(s) — {names}{_RESET}"
-    return f"{_YELLOW}⚠️  GPU      : not available — training on CPU{_RESET}"
-
-
 def _print_header(exp_dir: str, cfg: CVBenchConfig):
     w = 55
     print("━" * w)
@@ -36,7 +21,6 @@ def _print_header(exp_dir: str, cfg: CVBenchConfig):
     n_transforms = len(cfg.augmentation.transforms)
     print(f" Aug       : {n_transforms} transform(s)")
     print(f" Output    : {exp_dir}")
-    print(f" {_gpu_status_line()}")
     print("━" * w)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "scikit-learn",
     "matplotlib",
     "pandas",
+    "tqdm",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Added `tqdm` progress bar to the evaluation loop (single-pass, no double dataset scan)
- GPU/CPU status line now printed as the very first output for both `evaluate` and `train` commands
- Suppressed TF/XLA/absl log noise in `evaluate` (`TF_CPP_MIN_LOG_LEVEL=3`, `tf.get_logger`, `absl.logging`)

Closes #18