### PR TITLE
fix: pin all dependencies to exact versions, resolve keras/keras-hub incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,24 +7,30 @@ name = "cvbench"
 version = "0.7.0"
 requires-python = ">=3.10"
 dependencies = [
-    "tensorflow[and-cuda]",
-    "keras",
-    "keras-hub",
-    "tokenizers",
-    "sentencepiece",
-    "click",
-    "pyyaml",
-    "scikit-learn",
-    "matplotlib",
-    "pandas",
-    "tqdm",
+    "tensorflow==2.16.2",
+    "keras==3.5.0",
+    "keras-hub==0.19.0",
+    "tokenizers==0.22.2",
+    "sentencepiece==0.2.1",
+    "click==8.3.2",
+    "pyyaml==6.0.3",
+    "scikit-learn==1.7.2",
+    "matplotlib==3.10.8",
+    "pandas==2.3.3",
+    "tqdm==4.67.3",
 ]
 
 [project.optional-dependencies]
+gpu-mac = [
+    "tensorflow-metal",
+]
+gpu-linux = [
+    "tensorflow[and-cuda]==2.16.2",
+]
 dev = [
-    "pytest",
-    "pytest-cov",
-    "commitizen",
+    "pytest==9.0.3",
+    "pytest-cov==7.1.0",
+    "commitizen==4.13.10",
 ]
 
 [project.scripts]
@@ -49,6 +55,9 @@ major_version_zero = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = [
+    "ignore:builtin type.*has no __module__ attribute:DeprecationWarning",
+]
 markers = [
     "tf: marks tests that require TensorFlow (deselect with '-m \"not tf\"')",
 ]


### PR DESCRIPTION
## Summary

- Pins `keras==3.5.0` and `keras-hub==0.19.0` to resolve `ImportError: cannot import name 'ops' from 'keras'` — keras-hub 0.19+ requires Keras 3.x which introduced `keras.ops`
- Pins `tensorflow==2.16.2` (first TF release with Keras 3.x backend support); drops `[and-cuda]` from base deps as CUDA packages are Linux-only
- Adds `gpu-mac` and `gpu-linux` optional extras for platform-specific GPU support
- Pins all remaining dependencies to exact versions for reproducible installs
- Suppresses SWIG `DeprecationWarning` from TensorFlow C extensions in pytest config

## Test plan

- [ ] `pip install -e ".[dev]"` installs cleanly on macOS
- [ ] `python -m pytest -m "not tf"` — all non-TF tests pass
- [ ] `python -m pytest tests/test_model.py` — previously failing model tests now pass with no warnings

Closes #26