### PR TITLE
fix: opt into Node.js 24 for GitHub Actions and clean up GPU status messages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     outputs:
       released: ${{ steps.bump.outputs.released }}
       version: ${{ steps.bump.outputs.version }}
@@ -61,6 +63,8 @@ jobs:
     needs: release
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/src/cvbench/cli/evaluate.py
+++ b/src/cvbench/cli/evaluate.py
@@ -35,9 +35,9 @@ def evaluate(experiment, output_dir):
     gpus = tf.config.list_physical_devices("GPU")
     if gpus:
         names = ", ".join(g.name for g in gpus)
-        print(f"\033[92m🟢 GPU      : {len(gpus)} device(s) — {names}\033[0m")
+        print(f"\033[92m🟢 GPU detected: {len(gpus)} device(s) — {names}\033[0m")
     else:
-        print(f"\033[93m⚠️  GPU      : not available — evaluating on CPU\033[0m")
+        print(f"\033[93m⚠️ GPU not available, evaluating on CPU\033[0m")
 
     cfg = load_config(run_dir)
 

--- a/src/cvbench/cli/train.py
+++ b/src/cvbench/cli/train.py
@@ -65,9 +65,9 @@ def train(
     gpus = tf.config.list_physical_devices("GPU")
     if gpus:
         names = ", ".join(g.name for g in gpus)
-        print(f"\033[92m🟢 GPU      : {len(gpus)} device(s) — {names}\033[0m")
+        print(f"\033[92m🟢 GPU detected: {len(gpus)} device(s) — {names}\033[0m")
     else:
-        print(f"\033[93m⚠️  GPU      : not available — training on CPU\033[0m")
+        print(f"\033[93m⚠️ GPU not available, training on CPU\033[0m")
 
     class_weight_cfg = _parse_class_weight(class_weight_raw)
 


### PR DESCRIPTION
## Summary

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to all jobs in `ci.yaml` and `release.yaml` to opt into Node.js 24 ahead of the forced migration on June 2nd, 2026
- Cleaned up GPU availability status messages in `train.py` and `evaluate.py` (removed excessive whitespace and colons)

Closes #29