### PR TITLE
feat: polish CLI output readability and visual hierarchy

### DIFF
--- a/src/cvbench/cli/evaluate.py
+++ b/src/cvbench/cli/evaluate.py
@@ -9,6 +9,7 @@ os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
 import click
 import keras
 
+from cvbench.core import _fmt
 from cvbench.core.config import load_config
 from cvbench.core.data import build_dataset, get_class_names
 from cvbench.core.runs import resolve_run_dir
@@ -35,9 +36,9 @@ def evaluate(experiment, output_dir):
     gpus = tf.config.list_physical_devices("GPU")
     if gpus:
         names = ", ".join(g.name for g in gpus)
-        print(f"\033[92m🟢 GPU detected: {len(gpus)} device(s) — {names}\033[0m")
+        print(_fmt.green(f"🟢 GPU detected: {len(gpus)} device(s) — {names}"))
     else:
-        print(f"\033[93m⚠️ GPU not available, evaluating on CPU\033[0m")
+        print(_fmt.yellow("⚠️  GPU not available, evaluating on CPU"))
 
     cfg = load_config(run_dir)
 
@@ -46,7 +47,7 @@ def evaluate(experiment, output_dir):
         test_ds = build_dataset(cfg.data.test_dir, class_names, cfg, training=False)
 
     n_test = sum(1 for _ in Path(cfg.data.test_dir).glob("*/*"))
-    print(f" Found {n_test} files for evaluation ({len(class_names)} classes).")
+    print(_fmt.dim(f" Found {n_test} files for evaluation ({len(class_names)} classes)."))
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Skipping variable loading for optimizer")

--- a/src/cvbench/cli/runs.py
+++ b/src/cvbench/cli/runs.py
@@ -1,7 +1,18 @@
 import click
 
+from cvbench.core import _fmt
 from cvbench.core.runs import scan_experiments, best_experiment, resolve_run_dir, EXPERIMENTS_DIR
 from cvbench.core.config import load_config
+
+
+def _fit(s: str, width: int) -> str:
+    """Fit string to width using a middle ellipsis, preserving start and end."""
+    if len(s) <= width:
+        return s
+    keep = width - 1  # 1 char for the ellipsis
+    head = keep // 2
+    tail = keep - head
+    return s[:head] + "…" + s[-tail:]
 
 
 _DEFAULT_EXPERIMENTS_DIR = EXPERIMENTS_DIR
@@ -24,15 +35,16 @@ def list_runs(experiments_dir, sort):
         print(f" No experiments found in '{experiments_dir}'.")
         return
 
-    w = 80
-    print("━" * w)
+    tr = _fmt.rule(76, "white")
+    print(tr)
     print(f" {'Run':<45} {'Status':<12} {'Val Acc':>8}  {'Epochs':>6}")
-    print("━" * w)
+    print(tr)
     for r in entries:
         acc = r.get("val_accuracy")
         acc_str = f"{acc:.4f}" if acc is not None else "  —   "
-        print(f" {r['name']:<45} {r.get('status', '?'):<12} {acc_str:>8}  {r.get('epochs_run', '?'):>6}")
-    print("━" * w)
+        name = _fit(r['name'], 45)
+        print(f" {name:<45} {r.get('status', '?'):<12} {acc_str:>8}  {r.get('epochs_run', '?'):>6}")
+    print(tr)
 
 
 @runs.command()
@@ -67,16 +79,17 @@ def compare(experiment_a, experiment_b):
     name_a = a.get("name", run_a)
     name_b = b.get("name", run_b)
 
-    w = 75
-    print("━" * w)
-    print(f" {'Field':<22} {name_a[:24]:<26} {name_b[:24]:<26}")
-    print("━" * w)
+    col_w = 26
+    tr = _fmt.rule(79, "white")
+    print(tr)
+    print(f" {'Field':<22}  {_fit(name_a, col_w):<{col_w}}  {_fit(name_b, col_w):<{col_w}}")
+    print(tr)
     for f in fields:
         va = str(a.get(f, "—"))
         vb = str(b.get(f, "—"))
         diff = " ◀" if va != vb else ""
-        print(f" {f:<22} {va:<26} {vb:<26}{diff}")
-    print("━" * w)
+        print(f" {f:<22}  {va:<26}  {vb:<26}{diff}")
+    print(tr)
 
 
 @runs.command()
@@ -91,10 +104,9 @@ def best(experiments_dir, metric):
         print(f" No experiments with metric '{metric}' found in '{experiments_dir}'.")
         return
 
-    w = 55
-    print("━" * w)
-    print(f" CVBench — best run by {metric}")
-    print("━" * w)
+    print(_fmt.rule())
+    print(f" {_fmt.bold(f'CVBench — best run by {metric}')}")
+    print(_fmt.rule())
     for k, v in run.items():
         print(f" {k:<22}: {v}")
-    print("━" * w)
+    print(_fmt.rule())

--- a/src/cvbench/cli/train.py
+++ b/src/cvbench/cli/train.py
@@ -2,6 +2,7 @@ import json
 
 import click
 
+from cvbench.core import _fmt
 from cvbench.core.config import build_config, save_config
 from cvbench.core.data import (
     build_datasets,
@@ -65,9 +66,9 @@ def train(
     gpus = tf.config.list_physical_devices("GPU")
     if gpus:
         names = ", ".join(g.name for g in gpus)
-        print(f"\033[92m🟢 GPU detected: {len(gpus)} device(s) — {names}\033[0m")
+        print(_fmt.green(f"🟢 GPU detected: {len(gpus)} device(s) — {names}"))
     else:
-        print(f"\033[93m⚠️ GPU not available, training on CPU\033[0m")
+        print(_fmt.yellow("⚠️  GPU not available, training on CPU"))
 
     class_weight_cfg = _parse_class_weight(class_weight_raw)
 

--- a/src/cvbench/core/_fmt.py
+++ b/src/cvbench/core/_fmt.py
@@ -1,0 +1,56 @@
+"""Terminal formatting helpers for CVBench CLI output.
+
+Respects NO_COLOR env var and non-tty stdout for piped output / accessibility.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+
+def _color_enabled() -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    return sys.stdout.isatty()
+
+
+def term_width(fallback: int = 80) -> int:
+    return shutil.get_terminal_size((fallback, 24)).columns
+
+
+def _c(code: str, text: str) -> str:
+    if not _color_enabled():
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def bold(text: str) -> str:
+    return _c("1", text)
+
+
+def dim(text: str) -> str:
+    return _c("2", text)
+
+
+def green(text: str) -> str:
+    return _c("92", text)
+
+
+def yellow(text: str) -> str:
+    return _c("93", text)
+
+
+def rule(width: int | None = None, color: str = "dim") -> str:
+    """Separator line.
+
+    width  — explicit width; defaults to full terminal width.
+    color  — 'dim' (gray) or 'white' (bright white).
+    """
+    w = width if width is not None else term_width()
+    line = "─" * w
+    if not _color_enabled():
+        return line
+    if color == "white":
+        return f"\033[97m{line}\033[0m"
+    return f"\033[2m{line}\033[0m"

--- a/src/cvbench/core/data.py
+++ b/src/cvbench/core/data.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import tensorflow as tf
 
 from cvbench.core.config import CVBenchConfig
+from cvbench.core import _fmt
 
 
 def get_class_names(train_dir: str) -> list[str]:
@@ -63,23 +64,27 @@ def print_class_balance(
     min_count = min(counts)
     total = sum(counts)
     ratio = max_count / min_count if min_count > 0 else float("inf")
+    uniform = all(c == counts[0] for c in counts)
 
     bar_width = 20
     print(" Class distribution (train):")
     for cls, count in class_dist.items():
-        bar = "█" * int(count / max_count * bar_width)
         pct = count / total * 100
-        print(f"   {cls:<12} {count:>5}  {bar:<{bar_width}}  {pct:.1f}%")
+        if uniform:
+            print(f"   {cls:<12} {count:>5}  {pct:.1f}%")
+        else:
+            bar = "█" * int(count / max_count * bar_width)
+            print(f"   {cls:<12} {count:>5}  {bar:<{bar_width}}  {pct:.1f}%")
 
     if ratio >= 3.0:
         print()
-        print(f" ⚠ Imbalance ratio {ratio:.0f}:1 detected")
+        print(f" {_fmt.yellow(f'⚠ Imbalance ratio {ratio:.0f}:1 detected')}")
         if class_weight_cfg is None:
-            print("   Tip: rerun with --class-weight auto")
+            print(f"   {_fmt.dim('Tip: rerun with --class-weight auto')}")
         elif class_weight_cfg == "auto":
-            print("   ✓ class_weight=auto applied")
+            print(f"   {_fmt.green('✓ class_weight=auto applied')}")
         else:
-            print("   ✓ custom class weights applied")
+            print(f"   {_fmt.green('✓ custom class weights applied')}")
 
 
 def build_dataset(
@@ -141,8 +146,8 @@ def build_datasets(
         with contextlib.redirect_stdout(io.StringIO()):
             train_ds = build_dataset(cfg.data.train_dir, class_names, cfg, training=True)
             val_ds = build_dataset(cfg.data.val_dir, class_names, cfg, training=False)
-        print(f" Found {total_train} files for training ({len(class_names)} classes).")
-        print(f" Found {n_val} files for validation ({len(class_names)} classes).")
+        print(_fmt.dim(f" Found {total_train} files for training ({len(class_names)} classes)."))
+        print(_fmt.dim(f" Found {n_val} files for validation ({len(class_names)} classes)."))
         num_train_samples = total_train
     else:
         split = cfg.data.val_split
@@ -174,11 +179,11 @@ def build_datasets(
             )
         num_train_samples = math.floor(total_train * (1 - split))
         n_val_samples = total_train - num_train_samples
-        print(
+        print(_fmt.dim(
             f" Found {total_train} files belonging to {len(class_names)} classes"
             f" — auto-splitting ({pct_train}/{pct_val})"
-        )
-        print(f"   ├─ {num_train_samples} for training")
-        print(f"   └─ {n_val_samples} for validation")
+        ))
+        print(_fmt.dim(f"   ├─ {num_train_samples} for training"))
+        print(_fmt.dim(f"   └─ {n_val_samples} for validation"))
 
     return train_ds, val_ds, class_names, num_train_samples

--- a/src/cvbench/core/evaluator.py
+++ b/src/cvbench/core/evaluator.py
@@ -7,6 +7,8 @@ import keras
 import numpy as np
 import tqdm
 
+from cvbench.core import _fmt
+
 
 _MAX_SAMPLES_PER_CELL = 20
 
@@ -110,9 +112,9 @@ def evaluate(
         recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
         f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
         per_class[cls] = {
-            "precision": round(precision, 3),
-            "recall": round(recall, 3),
-            "f1": round(f1, 3),
+            "precision": round(precision, 4),
+            "recall": round(recall, 4),
+            "f1": round(f1, 4),
             "support": support,
         }
 
@@ -223,23 +225,29 @@ def _print_confusion_matrix(cm: np.ndarray, class_names: list[str]):
 def _print_report(report: dict, class_names: list[str], run_dir: str, out_dir: Path,
                   cm: np.ndarray | None = None):
     run_name = Path(run_dir).name
-    w = 55
-    print("━" * w)
-    print(f" CVBench — evaluate  |  run: {run_name}")
-    print("━" * w)
-    print(f" Split             : test")
-    print(f" Images evaluated  : {report['n_images']}")
-    print(f" Overall accuracy  : {report['overall_accuracy'] * 100:.1f}%")
+    n_images = report["n_images"]
+    overall_acc = f"{report['overall_accuracy'] * 100:.1f}%"
+    print(_fmt.rule())
+    print(f" {_fmt.bold('CVBench — evaluate')}  {_fmt.dim('|')}  {_fmt.dim('run: ' + run_name)}")
+    print(_fmt.rule())
+    print(_fmt.dim(" Split             : test"))
+    print(_fmt.dim(f" Images evaluated  : {n_images}"))
+    print(f" {_fmt.bold('Overall accuracy')}  : {_fmt.bold(overall_acc)}")
     if report["top3_accuracy"] is not None:
-        print(f" Top-3 accuracy    : {report['top3_accuracy'] * 100:.1f}%")
+        top3_acc = f"{report['top3_accuracy'] * 100:.1f}%"
+        print(f" {_fmt.bold('Top-3 accuracy')}    : {_fmt.bold(top3_acc)}")
     print()
-    print(" Per-class breakdown:")
+    print(f" {_fmt.bold('Per-class breakdown:')}")
+    max_cls = max(len(cls) for cls in report["per_class"]) if report["per_class"] else 10
     for cls, m in report["per_class"].items():
-        print(f"   {cls:<10} P: {m['precision']:.2f}  R: {m['recall']:.2f}  "
-              f"F1: {m['f1']:.2f}  ({m['support']} samples)")
+        p = f"{m['precision']:.4f}"
+        r = f"{m['recall']:.4f}"
+        f1 = f"{m['f1']:.4f}"
+        support = f"({m['support']} samples)"
+        print(f"   {cls:<{max_cls}}  P: {_fmt.bold(p)}  R: {_fmt.bold(r)}  F1: {_fmt.bold(f1)}  {_fmt.dim(support)}")
     print()
     if cm is not None:
         _print_confusion_matrix(cm, class_names)
-    print(f" Saved:")
-    print(f"   {out_dir / 'eval_report.json'}")
-    print("━" * w)
+    print(f" {_fmt.bold('Saved:')}")
+    print(f"   {_fmt.dim(str(out_dir / 'eval_report.json'))}")
+    print(_fmt.rule())

--- a/src/cvbench/core/trainer.py
+++ b/src/cvbench/core/trainer.py
@@ -7,21 +7,22 @@ import keras
 
 from cvbench.core.checkpoint import build_checkpoint_callback, prune_checkpoints
 from cvbench.core.config import CVBenchConfig, update_run_status
+from cvbench.core import _fmt
 
 
 def _print_header(exp_dir: str, cfg: CVBenchConfig):
-    w = 55
-    print("━" * w)
-    print(f" CVBench — train")
-    print("━" * w)
-    print(f" Data      : {cfg.data.data_dir}")
+    print(_fmt.rule())
+    print(f" {_fmt.bold('CVBench — train')}")
+    print(_fmt.rule())
+    print(f" Data      : {_fmt.dim(cfg.data.data_dir)}")
     print(f" Backbone  : {cfg.model.backbone}")
     print(f" Epochs    : {cfg.training.epochs}")
     print(f" LR        : {cfg.training.learning_rate}")
     n_transforms = len(cfg.augmentation.transforms)
     print(f" Aug       : {n_transforms} transform(s)")
-    print(f" Output    : {exp_dir}")
-    print("━" * w)
+    print(f" Output    : {_fmt.dim(exp_dir)}")
+    print(_fmt.rule())
+    print()  # breathing room before epoch output
 
 
 def train(
@@ -65,7 +66,7 @@ def train(
     _stop_flag = {"value": False}
 
     def _sigint_handler(signum, frame):
-        print("\n\n Interrupt received — finishing current batch then saving...\n")
+        print(f"\r\033[K\n {_fmt.yellow('⚠️  Interrupt received')} — finishing current batch then saving...\n")
         _stop_flag["value"] = True
 
     if cfg.training.interrupt.enabled:
@@ -107,7 +108,7 @@ def train(
         ckpt_name = f"interrupt_epoch{last_epoch:03d}.keras"
         interrupt_ckpt = str(run_dir / ckpt_name)
         model.save(interrupt_ckpt)
-        print(f"\n Checkpoint saved → {interrupt_ckpt}")
+        print(f"\n {_fmt.green('Checkpoint saved')} → {_fmt.dim(interrupt_ckpt)}")
         print(
             f" To resume: train {cfg.data.data_dir}"
             f" --from {exp_dir}"
@@ -136,12 +137,16 @@ def train(
         resume_checkpoint=interrupt_ckpt,
     )
 
-    w = 55
-    print("━" * w)
-    print(f" Training {'interrupted' if interrupted else 'complete'}")
-    for k, v in final_metrics.items():
-        print(f"   {k}: {v}")
-    print(f" Run directory → {run_dir}")
-    print("━" * w)
+    status_label = "interrupted" if interrupted else "complete"
+    status_color = _fmt.yellow if interrupted else _fmt.green
+    print()  # breathing room after last epoch line
+    print(_fmt.rule())
+    print(f" {_fmt.bold(f'Training {status_color(status_label)}')}")
+    if final_metrics:
+        max_k = max(len(k) for k in final_metrics)
+        for k, v in final_metrics.items():
+            print(f"   {_fmt.bold(f'{k:<{max_k}}')} : {v:.4f}")
+    print(f" Run directory → {_fmt.dim(str(run_dir))}")
+    print(_fmt.rule())
 
     return str(run_dir)


### PR DESCRIPTION
## Summary

- Add `_fmt.py` helper module for terminal formatting (full-width rules, ANSI color wrappers, `NO_COLOR` / non-tty support)
- Replace hardcoded `━` separators with full-terminal-width dim gray `─` rules in `train`, `evaluate`, and `runs` commands
- Apply color hierarchy: bold for key metrics/titles, dim for secondary info (paths, counts), green for success, yellow for warnings
- Add breathing room (blank lines) between logical output blocks
- Normalize float metrics to 4 decimal places in display
- Suppress bar chart in class distribution when all classes are uniform
- Clean up partial progress bar on `^C` interrupt with `\r\033[K`
- Use middle-ellipsis truncation (`start…end`) for long run names in `runs list` and `runs compare`
- Table rules in `runs` use table-width bright white `─` lines

Closes #31