### PR TITLE
feat: WebUI experiments explorer with interactive confusion matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 !src/
 !src/**/
 !src/**/*.py
+!src/**/*.html
+!src/**/*.css
+!src/**/*.js
 
 # Except tests
 !tests/

--- a/helper.sh
+++ b/helper.sh
@@ -122,7 +122,7 @@ action_augmentations(){
 
 action_serve(){
     action_activate
-    serve "$@"
+    python -c "from cvbench.web.app import main; main()" "$@"
 }
 
 action_test(){

--- a/src/cvbench/web/api/__init__.py
+++ b/src/cvbench/web/api/__init__.py
@@ -16,6 +16,12 @@ it here.
 
 try:
     from fastapi import APIRouter
+    from cvbench.web.api import runs
+
     router = APIRouter()
+    router.include_router(runs.router, tags=["runs"])
+    # router.include_router(training.router,   tags=["training"])
+    # router.include_router(evaluation.router, tags=["evaluation"])
+    # router.include_router(prediction.router, tags=["prediction"])
 except ImportError:
     router = None  # type: ignore[assignment]  # guarded in app.create_app()

--- a/src/cvbench/web/api/runs.py
+++ b/src/cvbench/web/api/runs.py
@@ -1,24 +1,105 @@
-"""Runs API — list and inspect experiment runs.
+"""Runs API — list and inspect experiment runs."""
 
-Planned endpoints
------------------
-    GET  /api/runs            → list all runs (name, status, val_accuracy, date)
-    GET  /api/runs/{name}     → full run detail: config + metrics + eval report
+import csv
+import json
+from pathlib import Path
 
-Each handler should call cvbench.services (not core directly):
-    from cvbench.core.runs import scan_experiments, resolve_run_dir
-    from cvbench.core.config import load_config
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
 
-TODO: implement (tracked in a follow-up GitHub issue)
-"""
-
-from fastapi import APIRouter
+from cvbench.core.runs import EXPERIMENTS_DIR, scan_experiments, resolve_run_dir
+from cvbench.core.config import load_config
 
 router = APIRouter()
 
 
-# @router.get("/runs")
-# def list_runs(): ...
+@router.get("/runs")
+def list_runs():
+    return scan_experiments(EXPERIMENTS_DIR)
 
-# @router.get("/runs/{name}")
-# def get_run(name: str): ...
+
+@router.get("/runs/{name}/images/{path:path}")
+def get_run_image(name: str, path: str):
+    try:
+        run_dir = resolve_run_dir(name)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Run '{name}' not found")
+
+    cfg = load_config(run_dir)
+    test_dir = Path(cfg.data.test_dir).resolve()
+    img_path = (test_dir / path).resolve()
+
+    try:
+        img_path.relative_to(test_dir)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not img_path.exists():
+        raise HTTPException(status_code=404, detail=f"Image not found: {path}")
+
+    return FileResponse(str(img_path))
+
+
+@router.get("/runs/{name}")
+def get_run(name: str):
+    try:
+        run_dir = resolve_run_dir(name)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Run '{name}' not found")
+
+    run_path = Path(run_dir)
+    cfg = load_config(run_dir)
+
+    training_log = []
+    log_path = run_path / "training_log.csv"
+    if log_path.exists():
+        with open(log_path) as f:
+            for row in csv.DictReader(f):
+                training_log.append({k: float(v) for k, v in row.items()})
+
+    eval_report = None
+    eval_path = run_path / "eval_report.json"
+    if eval_path.exists():
+        with open(eval_path) as f:
+            eval_report = json.load(f)
+
+    return {
+        "name": cfg.run.name or run_path.name,
+        "dir": run_dir,
+        "status": cfg.run.status,
+        "date": cfg.run.date,
+        "backbone": cfg.model.backbone,
+        "lr": cfg.training.learning_rate,
+        "epochs": cfg.training.epochs,
+        "epochs_run": cfg.run.epochs_run,
+        "val_accuracy": cfg.run.val_accuracy,
+        "test_accuracy": cfg.run.test_accuracy,
+        "resumable": cfg.run.resumable,
+        "notes": cfg.run.notes,
+        "config": {
+            "data": {
+                "data_dir": cfg.data.data_dir,
+                "classes": cfg.data.classes,
+                "batch_size": cfg.data.batch_size,
+                "input_size": cfg.model.input_size,
+            },
+            "model": {
+                "backbone": cfg.model.backbone,
+                "dropout": cfg.model.dropout,
+                "fine_tune_from_layer": cfg.model.fine_tune_from_layer,
+            },
+            "training": {
+                "epochs": cfg.training.epochs,
+                "learning_rate": cfg.training.learning_rate,
+                "class_weight": cfg.training.class_weight,
+                "checkpoints_strategy": cfg.training.checkpoints.strategy,
+                "lr_scheduler_patience": cfg.training.lr_scheduler.patience,
+            },
+            "augmentation": [
+                {"name": t.name, "prob": t.prob, **t.params}
+                for t in cfg.augmentation.transforms
+            ],
+        },
+        "training_log": training_log,
+        "eval_report": eval_report,
+    }

--- a/src/cvbench/web/static/css/style.css
+++ b/src/cvbench/web/static/css/style.css
@@ -1,0 +1,504 @@
+/* ── Pico CSS overrides — pull the base size down to ~13 px ─────────────────
+   Google Cloud Console / Workspace use 13–14 px Roboto for data-dense UIs.
+   Pico defaults to 16 px with 1 rem spacing everywhere; we trim both.       */
+
+:root {
+  --pico-font-size: 81.25%;          /* 13 px from 16 px root               */
+  --pico-line-height: 1.45;
+  --pico-spacing: 0.75rem;
+  --pico-typography-spacing-vertical: 0.75rem;
+  --pico-block-spacing-vertical: 0.75rem;
+  --pico-block-spacing-horizontal: 1rem;
+  --pico-table-cell-padding: 0.35rem 0.75rem;
+  --pico-form-element-spacing-vertical: 0.4rem;
+  --pico-form-element-spacing-horizontal: 0.75rem;
+
+  /* App tokens */
+  --sidebar-w: 196px;
+  --brand-color: #6366f1;
+  --section-label-size: 0.692rem;   /* 9 px — tight uppercase labels        */
+}
+
+/* Headings: Pico's defaults are huge for a dashboard. Set explicit px.      */
+h1 { font-size: 1.25rem; }          /* ~16 px */
+h2 { font-size: 1.077rem; }         /* ~14 px */
+h3 { font-size: 1rem; }
+h4 { font-size: 0.923rem; }         /* ~12 px */
+h5 { font-size: 0.846rem; }         /* ~11 px */
+
+body { margin: 0; }
+
+/* ── Layout ────────────────────────────────────────────────────────────────── */
+
+.app-layout { display: flex; min-height: 100vh; }
+
+/* ── Sidebar ───────────────────────────────────────────────────────────────── */
+
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  background: var(--pico-card-background-color, var(--card-background-color));
+  border-right: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  padding: 1rem 0.625rem;
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  padding: 0 0.25rem;
+}
+
+.brand-name {
+  font-size: 0.923rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.sidebar-nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.625rem;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--pico-color, var(--color));
+  font-size: 0.846rem;
+  font-weight: 500;
+  transition: background 0.1s, color 0.1s;
+}
+
+.nav-link:hover  { background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color)); }
+.nav-link.active { background: var(--brand-color); color: #fff; }
+
+.sidebar-footer {
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--pico-card-border-color, var(--card-border-color));
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.769rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  cursor: pointer;
+}
+
+.theme-toggle input { margin: 0; width: 0.9rem; height: 0.9rem; }
+
+/* ── Main content ──────────────────────────────────────────────────────────── */
+
+.main-content {
+  flex: 1;
+  padding: 1.5rem 2rem;
+  overflow-x: hidden;
+  min-width: 0;
+}
+
+/* ── Page header ───────────────────────────────────────────────────────────── */
+
+.page-header { margin-bottom: 1rem; }
+
+.page-header h2 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.back-link {
+  display: inline-block;
+  font-size: 0.769rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  text-decoration: none;
+  margin-bottom: 0.2rem;
+}
+
+.back-link:hover { color: var(--pico-color, var(--color)); }
+
+/* ── Status badges ─────────────────────────────────────────────────────────── */
+
+.badge {
+  display: inline-block;
+  padding: 0.1em 0.5em;
+  border-radius: 9999px;
+  font-size: 0.692rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+}
+
+.badge-done        { background: #c8e6c9; color: #1b5e20; }
+.badge-running     { background: #bbdefb; color: #0d47a1; }
+.badge-interrupted { background: #ffe8b2; color: #6d3a00; }
+.badge-failed      { background: #ffcdd2; color: #b71c1c; }
+
+[data-theme="dark"] .badge-done        { background: #1b3d28; color: #81c995; }
+[data-theme="dark"] .badge-running     { background: #0d2d5a; color: #82b1f5; }
+[data-theme="dark"] .badge-interrupted { background: #3d2200; color: #f5a623; }
+[data-theme="dark"] .badge-failed      { background: #4a1010; color: #f48a8a; }
+
+/* ── Metric cards ──────────────────────────────────────────────────────────── */
+
+.metric-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.metric-card {
+  text-align: center;
+  padding: 0.625rem 0.5rem;
+  margin: 0;
+}
+
+.metric-card small {
+  display: block;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-size: var(--section-label-size);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-bottom: 0.2rem;
+  white-space: nowrap;
+}
+
+.metric-card strong {
+  font-size: 1.231rem;    /* ~16 px — prominent but not giant */
+  font-weight: 600;
+  word-break: break-all;
+}
+
+/* ── Section label (reusable) ──────────────────────────────────────────────── */
+
+.section-label {
+  font-size: var(--section-label-size);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-weight: 600;
+  margin: 0 0 0.625rem;
+}
+
+/* ── Tabs ──────────────────────────────────────────────────────────────────── */
+
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  margin-bottom: 1rem;
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: 0.45rem 1rem;
+  font-size: 0.846rem;
+  font-weight: 500;
+  color: var(--pico-muted-color, var(--muted-color));
+  cursor: pointer;
+  border-radius: 0;
+  transition: color 0.12s, border-color 0.12s;
+  box-shadow: none;
+}
+
+.tab-btn:hover:not(:disabled) { color: inherit !important; background: none !important; }
+.tab-btn.active  { color: var(--brand-color); border-bottom-color: var(--brand-color); }
+.tab-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Config grid (training tab) ────────────────────────────────────────────── */
+
+.config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 0.625rem;
+  margin-bottom: 0.75rem;
+}
+
+.config-grid article { margin: 0; padding: 0.75rem 0.875rem; }
+
+/* Chart spans all columns — same width as the tile row above it */
+.config-grid-full { grid-column: 1 / -1; }
+
+.config-grid h4 {
+  margin: 0 0 0.5rem;
+  font-size: var(--section-label-size);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-weight: 600;
+}
+
+.config-grid dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.2rem 0.75rem;
+  margin: 0;
+  font-size: 0.846rem;
+}
+
+.config-grid dt { color: var(--pico-muted-color, var(--muted-color)); white-space: nowrap; }
+.config-grid dd { margin: 0; font-weight: 500; word-break: break-word; }
+
+#chart-container { padding: 0.75rem 0.875rem; }
+#chart-container h4 {
+  margin: 0 0 0.75rem;
+  font-size: var(--section-label-size);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-weight: 600;
+}
+#chart-container canvas { max-height: 240px; }
+
+/* ── Evaluation layout — stacked: metric cards → table → CM + gallery ──────── */
+
+.eval-table-card {
+  margin: 0 0 0.625rem;
+  padding: 0.875rem;
+}
+
+.eval-table-card h4,
+.cm-card h4 {
+  margin: 0 0 0.625rem;
+  font-size: var(--section-label-size);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-weight: 600;
+}
+
+.eval-table-card table { font-size: 0.846rem; }
+.eval-table-card th,
+.eval-table-card td { padding: 0.3rem 0.6rem; }
+
+/* Confusion matrix + gallery: side by side, stacks on narrow screens */
+
+.cm-gallery-layout {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.625rem;
+  align-items: start;
+}
+
+@media (max-width: 700px) {
+  .cm-gallery-layout { grid-template-columns: 1fr; }
+}
+
+.cm-card {
+  margin: 0;
+  padding: 0.875rem;
+  width: fit-content;
+  min-width: 0;
+}
+
+.cm-hint {
+  font-weight: 400;
+  font-size: 0.769rem;
+  color: var(--pico-muted-color, var(--muted-color));
+}
+
+/* ── Confusion matrix ──────────────────────────────────────────────────────── */
+
+.cm-wrap { overflow-x: auto; }
+
+.cm-axis-label {
+  font-size: 0.692rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-muted-color, var(--muted-color));
+  text-align: center;
+  margin-bottom: 0.2rem;
+}
+
+.cm-grid {
+  display: grid;
+  gap: 2px;
+  width: fit-content;
+}
+
+.cm-corner { background: transparent; }
+
+.cm-col-header {
+  font-size: 0.692rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 3px 5px;
+  background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color));
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.cm-row-header {
+  font-size: 0.692rem;
+  font-weight: 600;
+  text-align: right;
+  padding: 3px 6px 3px 3px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  white-space: nowrap;
+  background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color));
+  border-radius: 3px;
+}
+
+.cm-cell {
+  min-width: 40px;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.769rem;
+  font-weight: 700;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: transform 0.1s, box-shadow 0.1s;
+  user-select: none;
+}
+
+.cm-cell:hover {
+  transform: scale(1.12);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  z-index: 2;
+  position: relative;
+}
+
+.cm-cell.cm-zero { cursor: default; opacity: 0.15; }
+.cm-cell.cm-zero:hover { transform: none; box-shadow: none; }
+[data-theme="dark"] .cm-cell.cm-zero { opacity: 0.1; }
+
+.cm-legend {
+  font-size: 0.692rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  margin-top: 0.375rem;
+}
+
+/* ── Gallery panel ─────────────────────────────────────────────────────────── */
+
+.gallery-panel {
+  padding: 0.875rem;
+  background: var(--pico-card-background-color, var(--card-background-color));
+  border: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  border-radius: var(--pico-border-radius, 8px);
+}
+
+.gallery-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.625rem;
+}
+
+.gallery-header h5 { margin: 0; font-size: 0.846rem; }
+
+.gallery-header button { padding: 0.15rem 0.5rem; font-size: 0.769rem; }
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 0.4rem;
+}
+
+.gallery-thumb { margin: 0; text-align: center; }
+
+.gallery-thumb img {
+  width: 100%;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 5px;
+  border: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  transition: border-color 0.1s;
+  cursor: zoom-in;
+}
+
+.gallery-thumb img:hover { border-color: var(--brand-color); }
+
+.gallery-thumb figcaption {
+  font-size: 0.692rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  margin-top: 0.15rem;
+}
+
+.gallery-empty { color: var(--pico-muted-color, var(--muted-color)); font-size: 0.846rem; }
+
+/* ── Compare tab ───────────────────────────────────────────────────────────── */
+
+.compare-diff td { background: rgba(245,158,11,0.1); }
+[data-theme="dark"] .compare-diff td { background: rgba(245,158,11,0.08); }
+.compare-diff-note { font-size: 0.769rem; color: var(--pico-muted-color, var(--muted-color)); margin-top: 0.375rem; }
+
+/* ── Runs table ────────────────────────────────────────────────────────────── */
+
+.runs-table { font-size: 0.846rem; }
+.runs-table th { font-size: 0.692rem; text-transform: uppercase; letter-spacing: 0.06em; }
+.runs-table td, .runs-table th { padding: 0.35rem 0.75rem; }
+
+.runs-table tbody tr {
+  cursor: pointer;
+  transition: background 0.08s;
+}
+.runs-table tbody tr:hover td {
+  background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color));
+}
+
+.overflow-x { overflow-x: auto; }
+
+/* ── Error ─────────────────────────────────────────────────────────────────── */
+
+.error-msg {
+  color: #dc2626;
+  padding: 0.75rem 1rem;
+  background: #fee2e2;
+  border-radius: 6px;
+  font-size: 0.846rem;
+}
+
+[data-theme="dark"] .error-msg { background: #450a0a; color: #fca5a5; }
+
+/* ── Modal ─────────────────────────────────────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.65);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.modal-box {
+  background: var(--pico-card-background-color, var(--card-background-color));
+  border-radius: 10px;
+  padding: 1rem;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
+}
+
+.modal-box img {
+  max-width: 100%;
+  max-height: 75vh;
+  border-radius: 6px;
+  display: block;
+}

--- a/src/cvbench/web/static/index.html
+++ b/src/cvbench/web/static/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CVBench</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <div class="app-layout">
+
+    <aside class="sidebar">
+      <div class="sidebar-brand">
+        <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true">
+          <rect width="28" height="28" rx="7" fill="#6366f1"/>
+          <path d="M7 21 L14 7 L21 21" stroke="white" stroke-width="2.5" stroke-linejoin="round" fill="none"/>
+          <circle cx="14" cy="14" r="3" fill="white"/>
+        </svg>
+        <span class="brand-name">CVBench</span>
+      </div>
+
+      <nav class="sidebar-nav">
+        <a href="#/" id="nav-runs" class="nav-link" onclick="setActive('nav-runs')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+          Experiments
+        </a>
+      </nav>
+
+      <div class="sidebar-footer">
+        <label class="theme-toggle" title="Toggle dark mode">
+          <input type="checkbox" id="theme-toggle" onchange="toggleTheme(this)" />
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          Dark mode
+        </label>
+      </div>
+    </aside>
+
+    <main class="main-content" id="page">
+      <p aria-busy="true">Loading…</p>
+    </main>
+
+  </div>
+
+  <div id="modal-overlay" class="modal-overlay" style="display:none" onclick="closeModal()">
+    <div class="modal-box" onclick="event.stopPropagation()">
+      <div id="modal-content"></div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+  <script src="/js/app.js"></script>
+</body>
+</html>

--- a/src/cvbench/web/static/js/app.js
+++ b/src/cvbench/web/static/js/app.js
@@ -1,0 +1,530 @@
+/* ── State ─────────────────────────────────────────────────────────────────── */
+
+let currentRun = null;
+let activeTab = 'training';
+let chartInstance = null;
+
+/* ── Router ────────────────────────────────────────────────────────────────── */
+
+window.addEventListener('hashchange', route);
+window.addEventListener('DOMContentLoaded', route);
+
+function route() {
+  const hash = location.hash;
+  if (!hash || hash === '#' || hash === '#/') {
+    showRunsList();
+  } else if (hash.startsWith('#/runs/')) {
+    showRunDetail(decodeURIComponent(hash.slice(7)));
+  }
+}
+
+function navigate(hash) {
+  location.hash = hash;
+}
+
+/* ── API helper ────────────────────────────────────────────────────────────── */
+
+async function api(path) {
+  const res = await fetch('/api' + path);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+/* ── Theme ─────────────────────────────────────────────────────────────────── */
+
+function toggleTheme(checkbox) {
+  document.documentElement.setAttribute('data-theme', checkbox.checked ? 'dark' : 'light');
+  localStorage.setItem('theme', checkbox.checked ? 'dark' : 'light');
+}
+
+(function initTheme() {
+  const saved = localStorage.getItem('theme') || 'light';
+  document.documentElement.setAttribute('data-theme', saved);
+  const cb = document.getElementById('theme-toggle');
+  if (cb) cb.checked = saved === 'dark';
+})();
+
+/* ── Nav active state ──────────────────────────────────────────────────────── */
+
+function setActive(id) {
+  document.querySelectorAll('.nav-link').forEach(el => el.classList.remove('active'));
+  if (id) {
+    const el = document.getElementById(id);
+    if (el) el.classList.add('active');
+  }
+}
+
+/* ── Runs list ─────────────────────────────────────────────────────────────── */
+
+async function showRunsList() {
+  setActive('nav-runs');
+  const page = document.getElementById('page');
+  page.innerHTML = '<p aria-busy="true">Loading experiments…</p>';
+  try {
+    const runs = await api('/runs');
+    page.innerHTML = buildRunsList(runs);
+  } catch (e) {
+    page.innerHTML = `<p class="error-msg">Failed to load runs: ${e.message}</p>`;
+  }
+}
+
+function buildRunsList(runs) {
+  if (runs.length === 0) {
+    return `
+      <div class="page-header"><h2>Experiments</h2></div>
+      <article><p>No experiments found. Run <kbd>train</kbd> to create one.</p></article>
+    `;
+  }
+
+  const rows = runs.map(r => `
+    <tr onclick="navigate('#/runs/${encodeURIComponent(r.name)}')">
+      <td><strong>${r.name}</strong></td>
+      <td>${r.backbone}</td>
+      <td>${r.date || '—'}</td>
+      <td><span class="badge badge-${r.status}">${r.status}</span></td>
+      <td>${r.val_accuracy != null ? (r.val_accuracy * 100).toFixed(1) + '%' : '—'}</td>
+      <td>${r.test_accuracy != null ? (r.test_accuracy * 100).toFixed(1) + '%' : '—'}</td>
+      <td>${r.epochs_run} / ${r.epochs}</td>
+    </tr>
+  `).join('');
+
+  return `
+    <div class="page-header"><h2>Experiments <small style="font-size:0.85rem;font-weight:400;color:var(--muted-color)">${runs.length} run${runs.length !== 1 ? 's' : ''}</small></h2></div>
+    <div class="overflow-x">
+      <table class="runs-table">
+        <thead>
+          <tr>
+            <th>Name</th><th>Backbone</th><th>Date</th><th>Status</th>
+            <th>Val Acc</th><th>Test Acc</th><th>Epochs</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+/* ── Run detail ────────────────────────────────────────────────────────────── */
+
+async function showRunDetail(name) {
+  setActive('');
+  const page = document.getElementById('page');
+  page.innerHTML = '<p aria-busy="true">Loading run…</p>';
+  try {
+    const run = await api(`/runs/${encodeURIComponent(name)}`);
+    currentRun = run;
+    page.innerHTML = buildRunDetail(run);
+    switchTab(activeTab);
+  } catch (e) {
+    page.innerHTML = `<p class="error-msg">Run '${name}' not found: ${e.message}</p>`;
+  }
+}
+
+function buildRunDetail(run) {
+  const hasEval = run.eval_report != null;
+  return `
+    <div class="page-header">
+      <div>
+        <a href="#/" class="back-link" onclick="setActive('nav-runs')">← Experiments</a>
+        <h2>${run.name} <span class="badge badge-${run.status}">${run.status}</span></h2>
+      </div>
+    </div>
+
+    <div class="metric-cards">
+      ${card('Val Accuracy',  fmtAcc(run.val_accuracy))}
+      ${card('Test Accuracy', fmtAcc(run.test_accuracy))}
+      ${card('Backbone',      run.backbone)}
+      ${card('Epochs',        run.epochs_run + ' / ' + run.epochs)}
+      ${card('Learning Rate', run.lr)}
+      ${card('Date',          run.date || '—')}
+    </div>
+
+    <div class="tabs">
+      <button class="tab-btn" id="tab-training" onclick="switchTab('training')">Training</button>
+      <button class="tab-btn" id="tab-eval"     onclick="switchTab('eval')"     ${!hasEval ? 'disabled title="Run evaluation first"' : ''}>Evaluation</button>
+      <button class="tab-btn" id="tab-compare"  onclick="switchTab('compare')">Compare</button>
+    </div>
+    <div id="tab-content"></div>
+  `;
+}
+
+function card(label, value) {
+  return `
+    <article class="metric-card">
+      <small>${label}</small>
+      <strong>${value}</strong>
+    </article>
+  `;
+}
+
+function fmtAcc(v) {
+  return v != null ? (v * 100).toFixed(1) + '%' : '—';
+}
+
+/* ── Tab switcher ──────────────────────────────────────────────────────────── */
+
+function switchTab(tab) {
+  activeTab = tab;
+  ['training', 'eval', 'compare'].forEach(t => {
+    const btn = document.getElementById('tab-' + t);
+    if (btn) btn.classList.toggle('active', t === tab);
+  });
+
+  if (chartInstance) { chartInstance.destroy(); chartInstance = null; }
+
+  const content = document.getElementById('tab-content');
+  if (!content || !currentRun) return;
+
+  if (tab === 'training') {
+    content.innerHTML = buildTrainingTab(currentRun);
+    renderChart(currentRun);
+  } else if (tab === 'eval') {
+    content.innerHTML = buildEvalTab(currentRun);
+  } else if (tab === 'compare') {
+    content.innerHTML = buildCompareTab();
+    loadCompareOptions();
+  }
+}
+
+/* ── Training tab ──────────────────────────────────────────────────────────── */
+
+function buildTrainingTab(run) {
+  const augs = run.config.augmentation;
+  const augText = augs.length ? augs.map(t => t.name).join(', ') : 'None';
+  const hasLog = run.training_log.length > 0;
+
+  return `
+    <div class="config-grid">
+      <article>
+        <h4>Model</h4>
+        <dl>
+          <dt>Backbone</dt>      <dd>${run.config.model.backbone}</dd>
+          <dt>Input size</dt>    <dd>${run.config.data.input_size}px</dd>
+          <dt>Dropout</dt>       <dd>${run.config.model.dropout}</dd>
+          <dt>Fine-tune from</dt><dd>layer ${run.config.model.fine_tune_from_layer}</dd>
+        </dl>
+      </article>
+      <article>
+        <h4>Training</h4>
+        <dl>
+          <dt>Epochs</dt>         <dd>${run.epochs_run} / ${run.epochs}</dd>
+          <dt>Learning rate</dt>  <dd>${run.config.training.learning_rate}</dd>
+          <dt>Batch size</dt>     <dd>${run.config.data.batch_size}</dd>
+          <dt>Class weight</dt>   <dd>${run.config.training.class_weight || 'none'}</dd>
+          <dt>LR patience</dt>    <dd>${run.config.training.lr_scheduler_patience || 0}</dd>
+          <dt>Checkpoints</dt>    <dd>${run.config.training.checkpoints_strategy}</dd>
+        </dl>
+      </article>
+      <article>
+        <h4>Data & Augmentation</h4>
+        <dl>
+          <dt>Data dir</dt>       <dd><code>${run.config.data.data_dir}</code></dd>
+          <dt>Classes</dt>        <dd>${run.config.data.classes.join(', ')}</dd>
+          <dt>Augmentations</dt>  <dd>${augText}</dd>
+        </dl>
+      </article>
+
+      <article id="chart-container" class="config-grid-full">
+        <h4>Training Curves</h4>
+        ${hasLog ? '<canvas id="training-chart"></canvas>' : '<p style="color:var(--pico-muted-color,var(--muted-color))">No training log available.</p>'}
+      </article>
+    </div>
+  `;
+}
+
+function renderChart(run) {
+  if (!run.training_log.length) return;
+  const ctx = document.getElementById('training-chart');
+  if (!ctx) return;
+
+  const labels   = run.training_log.map(r => `Ep ${r.epoch + 1}`);
+  const trainAcc = run.training_log.map(r => +(r.accuracy   * 100).toFixed(2));
+  const valAcc   = run.training_log.map(r => +(r.val_accuracy * 100).toFixed(2));
+  const trainLoss= run.training_log.map(r => +r.loss.toFixed(4));
+  const valLoss  = run.training_log.map(r => +r.val_loss.toFixed(4));
+
+  chartInstance = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'Train Acc',  data: trainAcc,  borderColor: '#6366f1', backgroundColor: 'rgba(99,102,241,0.07)', yAxisID: 'yAcc', tension: 0.3, fill: true },
+        { label: 'Val Acc',    data: valAcc,    borderColor: '#22c55e', backgroundColor: 'rgba(34,197,94,0.07)',  yAxisID: 'yAcc', tension: 0.3, fill: true },
+        { label: 'Train Loss', data: trainLoss, borderColor: '#a78bfa', backgroundColor: 'transparent',           yAxisID: 'yLoss', tension: 0.3, borderDash: [5,3] },
+        { label: 'Val Loss',   data: valLoss,   borderColor: '#4ade80', backgroundColor: 'transparent',           yAxisID: 'yLoss', tension: 0.3, borderDash: [5,3] },
+      ],
+    },
+    options: {
+      responsive: true,
+      interaction: { mode: 'index', intersect: false },
+      plugins: { legend: { position: 'top' } },
+      scales: {
+        yAcc:  { type: 'linear', position: 'left',  title: { display: true, text: 'Accuracy (%)' }, min: 0, max: 100 },
+        yLoss: { type: 'linear', position: 'right', title: { display: true, text: 'Loss' }, grid: { drawOnChartArea: false } },
+      },
+    },
+  });
+}
+
+/* ── Evaluation tab ────────────────────────────────────────────────────────── */
+
+function buildEvalTab(run) {
+  const report = run.eval_report;
+  if (!report) return '<p class="error-msg">No evaluation report. Run <kbd>evaluate</kbd> first.</p>';
+
+  const classes = Object.keys(report.per_class);
+  const perClassRows = classes.map(cls => {
+    const m = report.per_class[cls];
+    return `
+      <tr>
+        <td>${cls}</td>
+        <td>${(m.precision * 100).toFixed(1)}%</td>
+        <td>${(m.recall    * 100).toFixed(1)}%</td>
+        <td>${(m.f1        * 100).toFixed(1)}%</td>
+        <td>${m.support}</td>
+      </tr>
+    `;
+  }).join('');
+
+  return `
+    <div class="metric-cards">
+      ${card('Overall Accuracy', fmtAcc(report.overall_accuracy))}
+      ${card('Top-3 Accuracy',   fmtAcc(report.top3_accuracy))}
+      ${card('Test Images',      report.n_images)}
+      ${card('Classes',          classes.length)}
+    </div>
+
+    <article class="eval-table-card">
+      <h4>Per-Class Metrics</h4>
+      <div class="overflow-x">
+        <table>
+          <thead><tr><th>Class</th><th>Precision</th><th>Recall</th><th>F1</th><th>Support</th></tr></thead>
+          <tbody>${perClassRows}</tbody>
+        </table>
+      </div>
+    </article>
+
+    <div class="cm-gallery-layout">
+      <article class="cm-card">
+        <h4>Confusion Matrix <small class="cm-hint">— click a cell to explore images</small></h4>
+        ${buildConfusionMatrix(report, run.name)}
+      </article>
+      <div id="gallery-panel" class="gallery-panel" style="display:none"></div>
+    </div>
+  `;
+}
+
+/* ── Confusion matrix ──────────────────────────────────────────────────────── */
+
+function buildConfusionMatrix(report, runName) {
+  if (!report.confusion_matrix) return '<p>No confusion matrix data.</p>';
+
+  const { classes, matrix } = report.confusion_matrix;
+  const n = classes.length;
+  const maxVal = Math.max(...matrix.flat().filter(v => v > 0), 1);
+
+  let cells = `<div class="cm-corner"></div>`;
+  cells += classes.map(c => `<div class="cm-col-header">${c}</div>`).join('');
+
+  for (let r = 0; r < n; r++) {
+    cells += `<div class="cm-row-header">${classes[r]}</div>`;
+    for (let c = 0; c < n; c++) {
+      const val = matrix[r][c];
+      const isDiag = r === c;
+      const intensity = val / maxVal;
+      // Single M3 blue scale — no green/red pre-judgment; diagonal stands out naturally
+      const alpha = val === 0 ? 0 : intensity * 0.82 + 0.12;
+      const bg = val === 0 ? '' : `rgba(25,118,210,${alpha.toFixed(2)})`;
+      const textColor = intensity > 0.42 ? '#fff' : '';
+      const zeroClass = val === 0 ? ' cm-zero' : '';
+
+      cells += `
+        <div class="cm-cell${zeroClass}"
+             style="${bg ? 'background:' + bg + ';' : ''}${textColor ? 'color:' + textColor + ';' : ''}"
+             title="${classes[r]} → ${classes[c]}: ${val}"
+             onclick="showGallery('${escHtml(runName)}', '${escHtml(classes[r])}', '${escHtml(classes[c])}', ${val})">
+          ${val}
+        </div>
+      `;
+    }
+  }
+
+  return `
+    <p class="cm-axis-label">Predicted →</p>
+    <div class="cm-wrap">
+      <div class="cm-grid" style="grid-template-columns:auto repeat(${n},1fr)">
+        ${cells}
+      </div>
+    </div>
+    <p class="cm-legend">Rows = Actual &nbsp;·&nbsp; Columns = Predicted</p>
+  `;
+}
+
+/* ── Gallery panel ─────────────────────────────────────────────────────────── */
+
+function showGallery(runName, trueClass, predClass, count) {
+  const panel = document.getElementById('gallery-panel');
+  if (!panel) return;
+
+  if (count === 0) { panel.style.display = 'none'; return; }
+
+  const samples = (currentRun.eval_report.samples || [])
+    .filter(s => s.true_class === trueClass && s.predicted_class === predClass);
+
+  const label = trueClass === predClass
+    ? `<strong>${trueClass}</strong> — correct predictions (${count})`
+    : `<strong>${trueClass}</strong> misclassified as <strong>${predClass}</strong> (${count})`;
+
+  let body;
+  if (samples.length === 0) {
+    body = `<p class="gallery-empty">No sample images stored for this cell.</p>`;
+  } else {
+    const thumbs = samples.map(s => {
+      const imgSrc = `/api/runs/${encodeURIComponent(runName)}/images/${imgPath(s.path)}`;
+      return `
+        <figure class="gallery-thumb" onclick="openModal('${imgSrc}')">
+          <img src="${imgSrc}" alt="${escHtml(s.path)}" loading="lazy" />
+          <figcaption>${(s.confidence * 100).toFixed(1)}%</figcaption>
+        </figure>
+      `;
+    }).join('');
+    body = `<div class="gallery-grid">${thumbs}</div>`;
+  }
+
+  panel.innerHTML = `
+    <div class="gallery-header">
+      <h5>${label}</h5>
+      <button class="outline" style="padding:0.2rem 0.6rem;font-size:0.8rem"
+              onclick="document.getElementById('gallery-panel').style.display='none'">✕</button>
+    </div>
+    ${body}
+  `;
+  panel.style.display = 'block';
+}
+
+function imgPath(path) {
+  return path.split('/').map(encodeURIComponent).join('/');
+}
+
+/* ── Image modal ───────────────────────────────────────────────────────────── */
+
+function openModal(src) {
+  document.getElementById('modal-content').innerHTML = `<img src="${src}" />`;
+  document.getElementById('modal-overlay').style.display = 'flex';
+}
+
+function closeModal() {
+  document.getElementById('modal-overlay').style.display = 'none';
+  document.getElementById('modal-content').innerHTML = '';
+}
+
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+
+/* ── Compare tab ───────────────────────────────────────────────────────────── */
+
+function buildCompareTab() {
+  return `
+    <article>
+      <p class="section-label">Compare with another run</p>
+      <div id="compare-picker"><p aria-busy="true">Loading runs…</p></div>
+      <div id="compare-result"></div>
+    </article>
+  `;
+}
+
+async function loadCompareOptions() {
+  const picker = document.getElementById('compare-picker');
+  if (!picker) return;
+  try {
+    const runs = await api('/runs');
+    const options = runs
+      .filter(r => r.name !== currentRun.name)
+      .map(r => `<option value="${escHtml(r.name)}">${r.name}</option>`)
+      .join('');
+
+    if (!options) {
+      picker.innerHTML = '<p style="color:var(--muted-color)">No other runs to compare with.</p>';
+      return;
+    }
+    picker.innerHTML = `
+      <select id="compare-select" onchange="loadCompareRun(this.value)">
+        <option value="">Select a run to compare…</option>
+        ${options}
+      </select>
+    `;
+  } catch (e) {
+    picker.innerHTML = `<p class="error-msg">Failed to load runs: ${e.message}</p>`;
+  }
+}
+
+async function loadCompareRun(name) {
+  if (!name) return;
+  const result = document.getElementById('compare-result');
+  result.innerHTML = '<p aria-busy="true">Loading…</p>';
+  try {
+    const other = await api(`/runs/${encodeURIComponent(name)}`);
+    result.innerHTML = buildCompareSideBySide(currentRun, other);
+  } catch (e) {
+    result.innerHTML = `<p class="error-msg">Failed to load run: ${e.message}</p>`;
+  }
+}
+
+function buildCompareSideBySide(a, b) {
+  const rows = [
+    ['Status',         a.status,           b.status],
+    ['Backbone',       a.backbone,         b.backbone],
+    ['Val Accuracy',   fmtAcc(a.val_accuracy),  fmtAcc(b.val_accuracy)],
+    ['Test Accuracy',  fmtAcc(a.test_accuracy), fmtAcc(b.test_accuracy)],
+    ['Learning Rate',  a.lr,               b.lr],
+    ['Epochs (done/total)', `${a.epochs_run}/${a.epochs}`, `${b.epochs_run}/${b.epochs}`],
+    ['Batch Size',     a.config.data.batch_size,       b.config.data.batch_size],
+    ['Input Size',     a.config.data.input_size + 'px',b.config.data.input_size + 'px'],
+    ['Dropout',        a.config.model.dropout,         b.config.model.dropout],
+    ['Classes',        a.config.data.classes.join(', '), b.config.data.classes.join(', ')],
+    ['Augmentations',  a.config.augmentation.map(t=>t.name).join(', ') || 'None',
+                       b.config.augmentation.map(t=>t.name).join(', ') || 'None'],
+    ['Checkpoint Strategy', a.config.training.checkpoints_strategy, b.config.training.checkpoints_strategy],
+    ['LR Patience',    a.config.training.lr_scheduler_patience, b.config.training.lr_scheduler_patience],
+  ];
+
+  const rowsHtml = rows.map(([label, av, bv]) => {
+    const diff = String(av) !== String(bv);
+    return `
+      <tr class="${diff ? 'compare-diff' : ''}">
+        <td>${label}</td>
+        <td>${av}</td>
+        <td>${bv}</td>
+      </tr>
+    `;
+  }).join('');
+
+  return `
+    <div class="overflow-x" style="margin-top:1rem">
+      <table>
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>${escHtml(a.name)}</th>
+            <th>${escHtml(b.name)}</th>
+          </tr>
+        </thead>
+        <tbody>${rowsHtml}</tbody>
+      </table>
+    </div>
+    <p class="compare-diff-note">Highlighted rows differ between runs.</p>
+  `;
+}
+
+/* ── Utilities ─────────────────────────────────────────────────────────────── */
+
+function escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary
- Implements a full single-page WebUI at `/` served by FastAPI (`cvbench serve`)
- REST API at `/api/runs` and `/api/runs/{name}` backed by `scan_experiments` / `load_config`
- Experiments list table with clickable rows → run detail page
- Run detail: metric cards, Training tab (config tiles + Chart.js curves), Evaluation tab (per-class table + interactive confusion matrix), Compare tab
- Confusion matrix uses M3 blue single-hue scale (colorblind-safe); clicking a cell shows misclassified sample images in a side gallery
- Pico CSS v2 + compact 13 px density inspired by Google Cloud Console; dark mode support throughout
- Path traversal guard on image-serving endpoint
- Fixed `.gitignore` to whitelist `.html`/`.css`/`.js` under `src/`

## Test plan
- [x] `./helper.sh serve` starts without errors
- [x] Experiments list loads at `http://127.0.0.1:8000`
- [x] Clicking a run opens detail page with all three tabs
- [x] Training curves render correctly in Training tab
- [x] Confusion matrix cells clickable; gallery appears on the right
- [x] Dark mode toggle works across all pages
- [x] Narrow viewport stacks CM + gallery vertically

Closes #38