### PR TITLE
feat: data group with explore command for brightness and class distribution analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After starting:
 ### Generate a synthetic dataset (smoke-test)
 
 ```bash
-docker exec cvbench generate --train 200 --val 50 --test 50
+docker exec cvbench data generate --train 200 --val 50 --test 50
 ```
 
 This writes to `data/synthetic/` by default. Point training at it immediately:
@@ -156,7 +156,8 @@ predict       --checkpoint <path> --input <image-or-folder>
 runs          list       [dir] [--sort val_accuracy|date|backbone]
 runs          compare    <experiment_a> <experiment_b>
 runs          best       [dir] [--metric val_accuracy|val_loss|test_accuracy]
-generate      [out_dir]  [--train N] [--val N] [--test N] [--image-size N]
+data          generate   [out_dir]  [--train N] [--val N] [--test N] [--image-size N]
+data          explore    <data_dir> [--split train|val|test] [--threshold N]
 augmentations list
 augmentations example    [light|standard|heavy|reference] [--output FILE]
 ```

--- a/helper.sh
+++ b/helper.sh
@@ -21,11 +21,13 @@ action_usage(){
     echo -e "  ${CMD}init${NC}                         create .venv and install all dependencies;"
     echo -e ""
     echo -e "${BOLD}Data Commands:${NC}"
-    echo -e "  ${CMD}generate${OPT} [opts]${NC}             generate synthetic shapes dataset;"
-    echo -e "    ${OPT}--output <dir>${NC}             destination directory (default: data/);"
-    echo -e "    ${OPT}--train/--val/--test <N>${NC}   images per class per split;"
-    echo -e "    ${OPT}--image-size <N>${NC}           image size in pixels (default: 64);"
-    echo -e "    ${OPT}--overwrite${NC}                replace existing output directory;"
+    echo -e "  ${CMD}data generate${OPT} [out_dir] [opts]${NC}  generate synthetic shapes dataset;"
+    echo -e "    ${OPT}--train/--val/--test <N>${NC}         images per class per split;"
+    echo -e "    ${OPT}--image-size <N>${NC}                 image size in pixels (default: 64);"
+    echo -e "    ${OPT}--overwrite${NC}                      replace existing output directory;"
+    echo -e "  ${CMD}data explore${OPT} <data_dir> [opts]${NC}  analyze per-class brightness distribution;"
+    echo -e "    ${OPT}--split <name>${NC}                   split to analyse (default: train);"
+    echo -e "    ${OPT}--threshold <N>${NC}                  bias warning threshold in 0-255 scale (default: 20);"
     echo -e ""
     echo -e "${BOLD}Training Commands:${NC}"
     echo -e "  ${CMD}train${OPT} <data_dir> [opts]${NC}      run training;"
@@ -91,9 +93,9 @@ action_activate(){
     source .venv/bin/activate
 }
 
-action_generate(){
+action_data(){
     action_activate
-    generate "$@"
+    data "$@"
 }
 
 action_train(){
@@ -156,8 +158,8 @@ case $1 in
     init)
         action_init
         ;;
-    generate)
-        action_generate ${@:2}
+    data)
+        action_data ${@:2}
         ;;
     train)
         action_train ${@:2}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ train        = "cvbench.cli.train:train"
 evaluate     = "cvbench.cli.evaluate:evaluate"
 predict      = "cvbench.cli.predict:predict"
 runs         = "cvbench.cli.runs:runs"
-generate     = "cvbench.cli.generate:generate"
+data          = "cvbench.cli.data:data"
 augmentations = "cvbench.cli.augmentations:augmentations"
 serve         = "cvbench.web.app:main"
 

--- a/src/cvbench/cli/data.py
+++ b/src/cvbench/cli/data.py
@@ -1,0 +1,111 @@
+"""Data management commands: generate synthetic datasets and explore data quality."""
+
+from pathlib import Path
+
+import click
+import numpy as np
+
+from cvbench.cli.generate import generate
+from cvbench.core.data import get_class_distribution, print_class_distribution
+
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"}
+
+
+@click.group()
+def data():
+    """Manage and inspect datasets."""
+
+
+data.add_command(generate, name="generate")
+
+
+def _mean_brightness(path: Path) -> float:
+    from PIL import Image
+    return float(np.array(Image.open(path).convert("L")).mean())
+
+
+@data.command("explore")
+@click.argument("data_dir")
+@click.option("--split", default="train", show_default=True,
+              help="Dataset split to analyse (train / val / test).")
+def explore(data_dir, split):
+    """Analyse per-class brightness and class distribution to detect potential bias.
+
+    DATA_DIR is the root dataset directory (containing train/, val/, test/
+    subdirectories) or a split directory directly.
+    """
+    from cvbench.core import _fmt
+
+    root = Path(data_dir)
+    split_dir = root / split if (root / split).is_dir() else root
+
+    class_dirs = sorted(p for p in split_dir.iterdir() if p.is_dir())
+    if not class_dirs:
+        raise click.ClickException(f"No class subdirectories found in '{split_dir}'")
+
+    stats = []
+    for cls_dir in class_dirs:
+        images = [f for f in cls_dir.iterdir() if f.suffix.lower() in _IMAGE_EXTS]
+        if not images:
+            continue
+        brightnesses = [_mean_brightness(f) for f in images]
+        arr = np.array(brightnesses)
+        stats.append({
+            "class": cls_dir.name,
+            "count": len(images),
+            "mean": float(arr.mean()),
+            "std": float(arr.std()),
+            "min": float(arr.min()),
+            "max": float(arr.max()),
+        })
+
+    if not stats:
+        raise click.ClickException("No images found.")
+
+    means = [s["mean"] for s in stats]
+    dataset_mean = float(np.mean(means))
+    std_of_means = float(np.std(means))
+    max_cls = max(len(s["class"]) for s in stats)
+
+    print(_fmt.rule())
+    print(f" {_fmt.bold('CVBench — data explore')}  {_fmt.dim('|')}  {_fmt.dim(str(split_dir))}")
+    print(_fmt.rule())
+    print(f" {_fmt.bold('Brightness distribution per class')}  {_fmt.dim('[0–255 scale]')}")
+    print()
+    print(_fmt.dim(f"   {'Class':<{max_cls}}  {'Images':>7}  {'Mean':>6}  {'Std':>6}  {'Min':>5}  {'Max':>5}"))
+
+    biased = [s for s in stats if std_of_means > 0 and abs(s["mean"] - dataset_mean) > std_of_means]
+
+    for s in stats:
+        flag = f"  {_fmt.yellow('⚠️')}" if s in biased else ""
+        mean_str = _fmt.bold(f"{s['mean']:>6.1f}")
+        print(
+            f"   {s['class']:<{max_cls}}  {s['count']:>7}  "
+            f"{mean_str}  {s['std']:>6.1f}  "
+            f"{s['min']:>5.1f}  {s['max']:>5.1f}{flag}"
+        )
+
+    print()
+    print(f" Dataset mean brightness : {_fmt.bold(f'{dataset_mean:.1f}')}")
+
+    if biased:
+        print()
+        for s in biased:
+            dev = s["mean"] - dataset_mean
+            direction = "brighter" if dev > 0 else "darker"
+            print(_fmt.yellow(f" ⚠️  '{s['class']}' is {abs(dev):.1f} units {direction} than the dataset mean"))
+        print()
+        print(f"   {_fmt.dim('Suggestion: consider brightness augmentation or per-image normalization.')}")
+    else:
+        print(_fmt.green(" ✓ No significant brightness bias detected."))
+
+    print()
+    dist = get_class_distribution(str(split_dir))
+    print_class_distribution(dist)
+    counts = list(dist.values())
+    std_of_counts = float(np.std(counts))
+    mean_of_counts = float(np.mean(counts))
+    imbalanced = std_of_counts > 0 and any(abs(c - mean_of_counts) > std_of_counts for c in counts)
+    if not imbalanced:
+        print(_fmt.green(" ✓ No significant class imbalance detected."))
+    print(_fmt.rule())

--- a/src/cvbench/core/data.py
+++ b/src/cvbench/core/data.py
@@ -54,31 +54,43 @@ def resolve_class_weights(
     return None
 
 
-def print_class_balance(
-    class_dist: dict[str, int],
-    class_weight_cfg,
-) -> None:
-    """Print per-class sample counts with a bar chart and an imbalance warning when needed."""
+def print_class_distribution(class_dist: dict[str, int]) -> None:
+    """Print per-class sample counts with a bar chart."""
     counts = list(class_dist.values())
     max_count = max(counts)
     min_count = min(counts)
     total = sum(counts)
     ratio = max_count / min_count if min_count > 0 else float("inf")
     uniform = all(c == counts[0] for c in counts)
+    max_cls = max(len(cls) for cls in class_dist)
 
     bar_width = 20
-    print(" Class distribution (train):")
+    print(f" {_fmt.bold('Class distribution:')}")
+    print(_fmt.dim(f"   {'Class':<{max_cls}}  {'Images':>6}  {'':^{bar_width}}  {'%':>5}"))
     for cls, count in class_dist.items():
         pct = count / total * 100
         if uniform:
-            print(f"   {cls:<12} {count:>5}  {pct:.1f}%")
+            print(f"   {cls:<{max_cls}}  {count:>6}  {'':^{bar_width}}  {pct:.1f}%")
         else:
             bar = "█" * int(count / max_count * bar_width)
-            print(f"   {cls:<12} {count:>5}  {bar:<{bar_width}}  {pct:.1f}%")
+            print(f"   {cls:<{max_cls}}  {count:>6}  {bar:<{bar_width}}  {pct:.1f}%")
+
+    std_counts = (sum((c - total / len(counts)) ** 2 for c in counts) / len(counts)) ** 0.5
+    imbalanced = std_counts > 0 and any(abs(c - total / len(counts)) > std_counts for c in counts)
+    if imbalanced:
+        print()
+        print(_fmt.yellow(f" ⚠️  Imbalance ratio {ratio:.0f}:1 detected"))
+
+
+def print_imbalance_warning(class_dist: dict[str, int], class_weight_cfg) -> None:
+    """Print an imbalance warning with class-weight tip when ratio >= 3:1."""
+    counts = list(class_dist.values())
+    max_count = max(counts)
+    min_count = min(counts) if min(counts) > 0 else 1
+    ratio = max_count / min_count
 
     if ratio >= 3.0:
-        print()
-        print(f" {_fmt.yellow(f'⚠ Imbalance ratio {ratio:.0f}:1 detected')}")
+        print(_fmt.yellow(f" ⚠️  Imbalance ratio {ratio:.0f}:1 detected"))
         if class_weight_cfg is None:
             print(f"   {_fmt.dim('Tip: rerun with --class-weight auto')}")
         elif class_weight_cfg == "auto":

--- a/src/cvbench/services/training.py
+++ b/src/cvbench/services/training.py
@@ -7,7 +7,7 @@ from cvbench.core.data import (
     build_datasets,
     get_class_distribution,
     get_class_names,
-    print_class_balance,
+    print_imbalance_warning,
     resolve_class_weights,
 )
 from cvbench.core.model import build_model
@@ -100,7 +100,7 @@ def run_training(
     cfg.model.num_classes = len(class_names)
 
     class_dist = get_class_distribution(cfg.data.train_dir)
-    print_class_balance(class_dist, cfg.training.class_weight)
+    print_imbalance_warning(class_dist, cfg.training.class_weight)
     resolved_weights = resolve_class_weights(
         cfg.training.class_weight, class_dist, class_names
     )


### PR DESCRIPTION
## Summary

- Replaces top-level `generate` command with a `data` group (`data generate`, `data explore`)
- `data explore <data_dir>` analyses per-class brightness distribution and class balance using auto-calibrated std-based detection — no manual threshold required
- Moves class distribution bar chart from training output into `data explore`; training now shows only a compact imbalance warning if needed
- Updates `helper.sh`, `README.md`, and `pyproject.toml` entry points accordingly

## Test plan

- [x] `data generate data/synthetic --overwrite` produces train/val/test splits
- [x] `data explore data/synthetic` shows brightness table + class distribution with ✓ or ⚠️ suggestions
- [x] `train data/synthetic --epochs 1` no longer prints bar chart, only imbalance warning if applicable
- [x] All non-TF tests pass (`pytest -m "not tf"`)

Closes #40