### PR TITLE
feat: add --val-split flag for train-only datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ train         <data_dir> [--epochs N] [--backbone NAME] [--lr FLOAT] [--batch-si
                          [--lr-patience N] [--lr-factor F] [--lr-min F]
                          [--fine-tune-from-layer N] [--augmentation FILE]
                          [--use-lcn] [--lcn-kernel-size N] [--lcn-epsilon F]
-                         [--resume CHECKPOINT] [--output DIR]
+                         [--val-split FLOAT] [--resume CHECKPOINT] [--output DIR]
 evaluate      <experiment>  [--output-dir PATH]
 predict       --checkpoint <path> --input <image-or-folder>
 runs          list       [dir] [--sort val_accuracy|date|backbone]

--- a/helper.sh
+++ b/helper.sh
@@ -45,6 +45,7 @@ action_usage(){
     echo -e "    ${OPT}--use-lcn${NC}                  enable Local Contrast Normalization (pattern-focused, brightness-invariant);"
     echo -e "    ${OPT}--lcn-kernel-size <N>${NC}      LCN neighbourhood size in pixels (default: 32);"
     echo -e "    ${OPT}--lcn-epsilon <float>${NC}      LCN stability constant (default: 1e-3);"
+    echo -e "    ${OPT}--val-split <float>${NC}        fraction of train used for val when no val/ dir exists (default: 0.2);"
     echo -e "    ${OPT}--resume <checkpoint>${NC}      resume from a checkpoint;"
     echo -e "  ${CMD}evaluate${OPT} <experiment> [opts]${NC}  evaluate a trained model (bare name or full path);"
     echo -e "    ${OPT}--split val|test${NC}           dataset split to evaluate on;"

--- a/src/cvbench/cli/train.py
+++ b/src/cvbench/cli/train.py
@@ -54,11 +54,13 @@ def _parse_class_weight(value: str | None):
               help="LCN neighbourhood size in pixels (default: 32).")
 @click.option("--lcn-epsilon", default=None, type=float,
               help="LCN stability constant for division (default: 1e-3).")
+@click.option("--val-split", default=None, type=float,
+              help="Fraction of train set to use for validation when no val/ directory exists (default: 0.2).")
 def train(
     data_dir, output_dir, from_dir, backbone, epochs, lr,
     batch_size, input_size, dropout, aug_file, resume, class_weight_raw,
     lr_patience, lr_factor, lr_min, fine_tune_from_layer,
-    use_lcn, lcn_kernel_size, lcn_epsilon,
+    use_lcn, lcn_kernel_size, lcn_epsilon, val_split,
 ):
     """Train a model on DATA_DIR.
 
@@ -86,4 +88,5 @@ def train(
         use_lcn=use_lcn or None,
         lcn_kernel_size=lcn_kernel_size,
         lcn_epsilon=lcn_epsilon,
+        val_split=val_split,
     )

--- a/src/cvbench/core/config.py
+++ b/src/cvbench/core/config.py
@@ -21,6 +21,7 @@ class DataConfig:
     classes: list = field(default_factory=list)
     batch_size: int = 16
     val_split: float = 0.2  # fraction of train used for val when val/ dir is absent
+    val_split_explicit: bool = False  # True when val_split was passed explicitly by the user
 
 
 @dataclass
@@ -209,6 +210,7 @@ def build_config(
     use_lcn: bool | None = None,
     lcn_kernel_size: int | None = None,
     lcn_epsilon: float | None = None,
+    val_split: float | None = None,
 ) -> CVBenchConfig:
     """Build a CVBenchConfig from CLI options.
 
@@ -254,6 +256,9 @@ def build_config(
         cfg.model.lcn_kernel_size = lcn_kernel_size
     if lcn_epsilon is not None:
         cfg.model.lcn_epsilon = lcn_epsilon
+    if val_split is not None:
+        cfg.data.val_split = val_split
+        cfg.data.val_split_explicit = True
 
     return cfg
 

--- a/src/cvbench/core/data.py
+++ b/src/cvbench/core/data.py
@@ -154,6 +154,11 @@ def build_datasets(
     total_train = sum(1 for _ in Path(cfg.data.train_dir).glob("*/*"))
 
     if os.path.isdir(cfg.data.val_dir):
+        if cfg.data.val_split_explicit:
+            print(_fmt.yellow(
+                f"⚠️  --val-split ignored: a val/ directory was found at {cfg.data.val_dir!r}."
+                " Remove val/ or omit --val-split to silence this warning."
+            ))
         n_val = sum(1 for _ in Path(cfg.data.val_dir).glob("*/*"))
         with contextlib.redirect_stdout(io.StringIO()):
             train_ds = build_dataset(cfg.data.train_dir, class_names, cfg, training=True)

--- a/src/cvbench/services/training.py
+++ b/src/cvbench/services/training.py
@@ -55,6 +55,7 @@ def run_training(
     use_lcn: bool | None = None,
     lcn_kernel_size: int | None = None,
     lcn_epsilon: float | None = None,
+    val_split: float | None = None,
 ) -> str:
     """Orchestrate a full training run.
 
@@ -89,6 +90,7 @@ def run_training(
         use_lcn=use_lcn,
         lcn_kernel_size=lcn_kernel_size,
         lcn_epsilon=lcn_epsilon,
+        val_split=val_split,
     )
 
     if aug_file:


### PR DESCRIPTION
## Summary

- Adds `--val-split FLOAT` CLI option to `train` command (default: `0.2`)
- When a dataset has only `train/` and `test/` directories (no `val/`), the split fraction is now user-configurable instead of hardcoded
- Emits a yellow warning and ignores `--val-split` if a `val/` directory is present

## Test plan

- [x] Train on a dataset with only `train/` + `test/` dirs, pass `--val-split 0.15` — confirm 85/15 split is reported
- [x] Train on a dataset with `val/` dir, pass `--val-split 0.3` — confirm warning is printed and `val/` is used as-is
- [x] Train without `--val-split` on a no-val dataset — confirm default 80/20 split still applies