### PR TITLE
fix: resume training broken when checkpoint has no epoch in filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,47 @@ The scheduler settings are saved to `config.yaml` and applied automatically when
 
 ---
 
+## Two-phase training (freeze → fine-tune)
+
+A common transfer-learning workflow is to first train with the backbone frozen, then unfreeze some layers and fine-tune at a lower learning rate.
+
+**Phase 1 — train classifier head only (backbone frozen):**
+
+```bash
+train data/ --epochs 30 --output experiments/phase1
+```
+
+**Phase 2 — unfreeze top layers and fine-tune:**
+
+```bash
+train data/ \
+  --from experiments/phase1 \
+  --resume experiments/phase1/best.keras \
+  --fine-tune-from-layer 100 \
+  --lr 1e-5 \
+  --epochs 50
+```
+
+`--from` loads the phase-1 config (backbone, input size, augmentation, etc.) and its recorded epoch count. `--resume` loads the saved weights. Training then continues from epoch 30 through epoch 50, adding 20 fine-tuning epochs — the training log is **appended**, so the full history (both phases) is preserved in `training_log.csv`.
+
+> **Important:** `--epochs N` means *end at epoch N*, not *run N more epochs*. If phase 1 ran 30 epochs and you want 20 more, set `--epochs 50`.
+
+**Resuming after an interrupt:**
+
+If training is interrupted mid-run, CVBench saves an `interrupt_epochNNN.keras` checkpoint and prints the exact resume command:
+
+```bash
+train data/ --from experiments/phase1 --resume experiments/phase1/interrupt_epoch023.keras --epochs 30
+```
+
+| Option | Description |
+|---|---|
+| `--from <exp_dir>` | Load backbone, hyperparameters, and epoch count from a previous experiment |
+| `--resume <checkpoint>` | Load weights from a `.keras` checkpoint and continue training from the recorded epoch |
+| `--fine-tune-from-layer N` | Unfreeze backbone layers from index N onward (`-1` = unfreeze all) |
+
+---
+
 ## Augmentation
 
 Augmentation is configured via a standalone YAML file and passed to `train` with `--augmentation`.

--- a/helper.sh
+++ b/helper.sh
@@ -46,7 +46,7 @@ action_usage(){
     echo -e "    ${OPT}--lcn-kernel-size <N>${NC}      LCN neighbourhood size in pixels (default: 32);"
     echo -e "    ${OPT}--lcn-epsilon <float>${NC}      LCN stability constant (default: 1e-3);"
     echo -e "    ${OPT}--val-split <float>${NC}        fraction of train used for val when no val/ dir exists (default: 0.2);"
-    echo -e "    ${OPT}--resume <checkpoint>${NC}      resume from a checkpoint;"
+    echo -e "    ${OPT}--resume <checkpoint>${NC}      resume from a checkpoint; use with --from to continue two-phase training (--epochs N means end at epoch N, not N more epochs);"
     echo -e "  ${CMD}evaluate${OPT} <experiment> [opts]${NC}  evaluate a trained model (bare name or full path);"
     echo -e "    ${OPT}--split val|test${NC}           dataset split to evaluate on;"
     echo -e "    ${OPT}--output-dir <path>${NC}        where to write eval outputs;"

--- a/src/cvbench/core/trainer.py
+++ b/src/cvbench/core/trainer.py
@@ -52,10 +52,15 @@ def train(
     if resume_checkpoint:
         print(f" Resuming from: {resume_checkpoint}")
         model.load_weights(resume_checkpoint)
-        import re
-        m = re.search(r"epoch[_]?(\d+)", Path(resume_checkpoint).stem)
-        if m:
-            initial_epoch = int(m.group(1))
+        if cfg.run.epochs_run > 0:
+            # Use the epoch count stored in config (reliable for all checkpoint names,
+            # including best.keras which carries no epoch number in its filename).
+            initial_epoch = cfg.run.epochs_run
+        else:
+            import re
+            m = re.search(r"epoch[_]?(\d+)", Path(resume_checkpoint).stem)
+            if m:
+                initial_epoch = int(m.group(1))
 
     # Callbacks
     callbacks = [


### PR DESCRIPTION
## Summary

- **Bug:** When resuming two-phase training with `best.keras` (or any checkpoint whose filename contains no epoch number), `initial_epoch` stayed at 0 because the filename regex had nothing to match. This caused Keras to restart from epoch 0 and the CSV logger to overwrite the phase-1 training history.
- **Fix:** Use `cfg.run.epochs_run` (already stored in the loaded config via `--from`) as `initial_epoch` when it is > 0. The filename regex is kept as a fallback for single-run interrupt resumes where no prior config is loaded.
- **Docs:** Added a "Two-phase training" section to `README.md` covering the freeze → fine-tune workflow, the `--epochs N` end-epoch convention, and interrupt resume. Updated the `--resume` hint in `helper.sh`.

## Test plan

- [x] Phase 1: `train data/ --epochs 30 --output exp1` — verify `config.yaml` contains `epochs_run: 30`
- [x] Phase 2: `train data/ --from exp1 --resume exp1/best.keras --epochs 50` — verify training starts at epoch 30 and `training_log.csv` contains rows from both phases
- [x] Interrupt resume: interrupt mid-run, resume from `interrupt_epochNNN.keras` — verify correct start epoch and appended CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)