### PR TITLE
feat: Grad-CAM explanation in WebUI gallery + resume training fix

### DIFF
--- a/src/cvbench/services/gradcam.py
+++ b/src/cvbench/services/gradcam.py
@@ -1,0 +1,177 @@
+"""Grad-CAM explanation service.
+
+Computes a Grad-CAM heatmap overlay for a single image given a Keras model
+checkpoint and a target class index.  Returns a base64-encoded PNG that can
+be embedded directly in an <img src="data:image/png;base64,..."> tag.
+
+The last Conv2D layer is located automatically, so this works with any
+standard CNN backbone (EfficientNet, MobileNet, ResNet, etc.).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import numpy as np
+
+
+def compute_gradcam(checkpoint: str, image_path: str, class_index: int) -> str:
+    """Return a base64 PNG of the Grad-CAM heatmap blended onto the original image.
+
+    Args:
+        checkpoint:  Path to the .keras model file.
+        image_path:  Path to the image file.
+        class_index: Target class index (the predicted or true class to explain).
+
+    Returns:
+        Base64-encoded PNG string (no data-URI prefix).
+    """
+    import tensorflow as tf
+    import keras
+
+    model = keras.saving.load_model(checkpoint)
+    input_size = model.input_shape[1]
+
+    img = tf.keras.utils.load_img(image_path, target_size=(input_size, input_size))
+    arr = tf.cast(tf.keras.utils.img_to_array(img)[None], tf.float32)  # (1,H,W,3)
+
+    with tf.GradientTape() as tape:
+        conv_outputs, predictions = _run_with_conv_output(model, arr, tape=tape)
+        if conv_outputs is None:
+            raise ValueError("No Conv2D layer found in model — Grad-CAM requires a CNN backbone.")
+        loss = predictions[:, class_index]
+
+    grads = tape.gradient(loss, conv_outputs)          # (1, h, w, filters)
+    pooled = tf.reduce_mean(grads, axis=(1, 2))[0]     # (filters,)
+    cam = tf.reduce_sum(conv_outputs[0] * pooled, axis=-1).numpy()  # (h, w)
+
+    cam = np.maximum(cam, 0)
+    if cam.max() > 0:
+        cam /= cam.max()
+
+    heatmap = _colorize(cam, input_size)               # (H, W, 3) uint8
+    original = np.array(img).astype(np.uint8)          # (H, W, 3)
+    blended = _blend(original, heatmap, alpha=0.45)    # (H, W, 3)
+
+    return _to_base64_png(blended)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _run_with_conv_output(model, arr, tape=None):
+    """Run the model and return (last_conv_output, predictions).
+
+    Handles nested backbones (and any pre-backbone layers like LCN) by splitting
+    model.layers into three ordered groups and running them sequentially:
+        pre_layers  → backbone grad-model → post_layers
+    This avoids two failure modes:
+      1. Keras graph-connectivity error when last_conv.output belongs to the
+         backbone's sub-graph rather than the top-level model's graph.
+      2. Pre-backbone preprocessing (e.g. LocalContrastNormalization) being
+         accidentally applied to backbone feature maps instead of the input.
+
+    Returns (None, None) when no Conv2D is found.
+    """
+    import keras
+
+    backbone, last_conv = _find_backbone_and_last_conv(model)
+    if last_conv is None:
+        return None, None
+
+    if backbone is not None:
+        # Partition layers: everything before backbone, backbone itself, everything after
+        pre_layers, post_layers = [], []
+        found = False
+        for layer in model.layers:
+            if isinstance(layer, keras.layers.InputLayer):
+                continue
+            if layer is backbone:
+                found = True
+                continue
+            (post_layers if found else pre_layers).append(layer)
+
+        # Grad model scoped entirely to the backbone sub-graph
+        conv_model = keras.Model(
+            inputs=backbone.inputs,
+            outputs=[last_conv.output, backbone.outputs[0]],
+        )
+
+        # Pre-backbone pass (e.g. LCN, rescaling, etc.)
+        x = arr
+        for layer in pre_layers:
+            x = layer(x, training=False)
+
+        # Backbone pass — intercept conv activations here
+        conv_outputs, x = conv_model(x, training=False)
+        if tape is not None:
+            tape.watch(conv_outputs)
+
+        # Post-backbone head (GlobalAveragePooling, Dense, Dropout, …)
+        for layer in post_layers:
+            x = layer(x, training=False)
+
+        return conv_outputs, x
+    else:
+        # Flat model — last_conv.output is directly reachable from model.inputs
+        conv_model = keras.Model(
+            inputs=model.inputs,
+            outputs=[last_conv.output, model.outputs[0]],
+        )
+        conv_outputs, predictions = conv_model(arr, training=False)
+        if tape is not None:
+            tape.watch(conv_outputs)
+        return conv_outputs, predictions
+
+
+def _find_backbone_and_last_conv(model):
+    """Return (backbone_layer_or_None, last_Conv2D_layer_or_None)."""
+    import keras
+
+    backbone = None
+    last_conv = None
+
+    for layer in model.layers:
+        if isinstance(layer, keras.layers.Conv2D):
+            last_conv = layer
+        elif hasattr(layer, "layers") and hasattr(layer, "inputs"):
+            # Nested functional sub-model — treat as backbone
+            backbone = layer
+            for sub in layer.layers:
+                if isinstance(sub, keras.layers.Conv2D):
+                    last_conv = sub
+
+    return backbone, last_conv
+
+
+def _colorize(cam: np.ndarray, size: int) -> np.ndarray:
+    """Resize CAM to (size, size) and apply jet colormap → uint8 RGB."""
+    from PIL import Image
+
+    cam_uint8 = (cam * 255).astype(np.uint8)
+    cam_img = Image.fromarray(cam_uint8, mode="L").resize(
+        (size, size), Image.BILINEAR
+    )
+    cam_arr = np.array(cam_img, dtype=np.float32) / 255.0  # [0,1]
+
+    # Jet colormap: blue→cyan→green→yellow→red
+    r = np.clip(1.5 - np.abs(cam_arr * 4 - 3), 0, 1)
+    g = np.clip(1.5 - np.abs(cam_arr * 4 - 2), 0, 1)
+    b = np.clip(1.5 - np.abs(cam_arr * 4 - 1), 0, 1)
+    rgb = np.stack([r, g, b], axis=-1)
+    return (rgb * 255).astype(np.uint8)
+
+
+def _blend(original: np.ndarray, heatmap: np.ndarray, alpha: float) -> np.ndarray:
+    """Alpha-blend heatmap over original image."""
+    return np.clip(
+        original.astype(np.float32) * (1 - alpha) + heatmap.astype(np.float32) * alpha,
+        0, 255,
+    ).astype(np.uint8)
+
+
+def _to_base64_png(arr: np.ndarray) -> str:
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")

--- a/src/cvbench/web/api/__init__.py
+++ b/src/cvbench/web/api/__init__.py
@@ -16,10 +16,11 @@ it here.
 
 try:
     from fastapi import APIRouter
-    from cvbench.web.api import runs
+    from cvbench.web.api import runs, explain
 
     router = APIRouter()
-    router.include_router(runs.router, tags=["runs"])
+    router.include_router(runs.router,    tags=["runs"])
+    router.include_router(explain.router, tags=["explain"])
     # router.include_router(training.router,   tags=["training"])
     # router.include_router(evaluation.router, tags=["evaluation"])
     # router.include_router(prediction.router, tags=["prediction"])

--- a/src/cvbench/web/api/explain.py
+++ b/src/cvbench/web/api/explain.py
@@ -1,0 +1,63 @@
+"""Explain API — Grad-CAM heatmap for a single image."""
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from cvbench.core.runs import resolve_run_dir
+from cvbench.core.config import load_config
+
+router = APIRouter()
+
+
+class GradCamRequest(BaseModel):
+    image_path: str
+    class_index: int
+
+
+@router.post("/runs/{name}/explain/gradcam")
+def gradcam(name: str, body: GradCamRequest):
+    try:
+        run_dir = resolve_run_dir(name)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Run '{name}' not found")
+
+    cfg = load_config(run_dir)
+
+    # Resolve and validate image path stays inside test_dir
+    test_dir = Path(cfg.data.test_dir).resolve()
+    img_path = (test_dir / body.image_path).resolve()
+    try:
+        img_path.relative_to(test_dir)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not img_path.exists():
+        raise HTTPException(status_code=404, detail=f"Image not found: {body.image_path}")
+
+    # Find the best checkpoint for this run
+    checkpoint = _find_checkpoint(Path(run_dir))
+    if checkpoint is None:
+        raise HTTPException(status_code=404, detail="No model checkpoint found for this run")
+
+    try:
+        from cvbench.services.gradcam import compute_gradcam
+        heatmap_b64 = compute_gradcam(
+            checkpoint=str(checkpoint),
+            image_path=str(img_path),
+            class_index=body.class_index,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    return JSONResponse({"heatmap_b64": heatmap_b64})
+
+
+def _find_checkpoint(run_dir: Path) -> Path | None:
+    for pattern in ("best_model.keras", "*.keras", "best_model.h5", "*.h5"):
+        matches = sorted(run_dir.glob(pattern))
+        if matches:
+            return matches[0]
+    return None

--- a/src/cvbench/web/static/css/style.css
+++ b/src/cvbench/web/static/css/style.css
@@ -414,28 +414,50 @@ body { margin: 0; }
 
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-  gap: 0.4rem;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.6rem;
 }
 
 .gallery-thumb { margin: 0; text-align: center; }
 
+.gallery-thumb .thumb-img-wrap { width: 100%; }
+
 .gallery-thumb img {
   width: 100%;
-  height: 72px;
+  height: 130px;
   object-fit: cover;
   border-radius: 5px;
   border: 1px solid var(--pico-card-border-color, var(--card-border-color));
-  transition: border-color 0.1s;
+  transition: border-color 0.15s;
   cursor: zoom-in;
 }
 
 .gallery-thumb img:hover { border-color: var(--brand-color); }
 
 .gallery-thumb figcaption {
-  font-size: 0.692rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
   color: var(--pico-muted-color, var(--muted-color));
-  margin-top: 0.15rem;
+  margin-top: 0.25rem;
+  gap: 0.25rem;
+}
+
+.explain-btn {
+  font-size: 0.7rem !important;
+  padding: 0.1rem 0.4rem !important;
+  margin: 0 !important;
+  line-height: 1.4 !important;
+  border-radius: 3px !important;
+  white-space: nowrap;
+}
+
+.explain-error {
+  display: block;
+  font-size: 0.615rem;
+  color: var(--pico-del-color, #c0392b);
+  margin-top: 0.1rem;
 }
 
 .gallery-empty { color: var(--pico-muted-color, var(--muted-color)); font-size: 0.846rem; }

--- a/src/cvbench/web/static/js/app.js
+++ b/src/cvbench/web/static/js/app.js
@@ -382,12 +382,22 @@ function showGallery(runName, trueClass, predClass, count) {
   if (samples.length === 0) {
     body = `<p class="gallery-empty">No sample images stored for this cell.</p>`;
   } else {
-    const thumbs = samples.map(s => {
+    const thumbs = samples.map((s, i) => {
       const imgSrc = `/api/runs/${encodeURIComponent(runName)}/images/${imgPath(s.path)}`;
+      const thumbId = `thumb-${Date.now()}-${i}`;
       return `
-        <figure class="gallery-thumb" onclick="openModal('${imgSrc}')">
-          <img src="${imgSrc}" alt="${escHtml(s.path)}" loading="lazy" />
-          <figcaption>${(s.confidence * 100).toFixed(1)}%</figcaption>
+        <figure class="gallery-thumb" id="${thumbId}">
+          <div class="thumb-img-wrap">
+            <img class="thumb-original" src="${imgSrc}" alt="${escHtml(s.path)}" loading="lazy"
+                 onclick="openModal('${imgSrc}')" />
+          </div>
+          <figcaption>
+            <span>${(s.confidence * 100).toFixed(1)}%</span>
+            <button class="explain-btn outline" title="Show Grad-CAM explanation"
+                    onclick="explainImage(event, '${escHtml(runName)}', '${escHtml(s.path)}', '${escHtml(s.predicted_class)}', '${thumbId}')">
+              Explain
+            </button>
+          </figcaption>
         </figure>
       `;
     }).join('');
@@ -403,6 +413,78 @@ function showGallery(runName, trueClass, predClass, count) {
     ${body}
   `;
   panel.style.display = 'block';
+}
+
+/* ── Grad-CAM explanation ──────────────────────────────────────────────────── */
+
+async function explainImage(event, runName, imagePath, predictedClass, thumbId) {
+  event.stopPropagation();
+  const figure = document.getElementById(thumbId);
+  if (!figure) return;
+
+  const btn = event.target;
+  const wrap = figure.querySelector('.thumb-img-wrap');
+  const img = wrap.querySelector('img');
+  const origSrc = `/api/runs/${encodeURIComponent(runName)}/images/${imgPath(imagePath)}`;
+
+  // Toggle: if heatmap is showing, revert to original
+  if (figure.dataset.explained === '1') {
+    img.src = origSrc;
+    img.onclick = () => openModal(origSrc);
+    btn.textContent = 'Explain';
+    figure.dataset.explained = '0';
+    return;
+  }
+
+  // If heatmap already fetched, just swap it back in
+  if (figure.dataset.heatmap) {
+    img.src = figure.dataset.heatmap;
+    img.onclick = () => openModal(figure.dataset.heatmap);
+    btn.textContent = 'Original';
+    figure.dataset.explained = '1';
+    return;
+  }
+
+  btn.textContent = '…';
+  btn.disabled = true;
+
+  const classes = currentRun?.eval_report?.confusion_matrix?.classes || [];
+  const classIndex = classes.indexOf(predictedClass);
+  if (classIndex === -1) {
+    btn.textContent = 'Explain';
+    btn.disabled = false;
+    const existing = figure.querySelector('.explain-error');
+    if (existing) existing.remove();
+    figure.insertAdjacentHTML('beforeend', '<small class="explain-error">Cannot resolve class index.</small>');
+    return;
+  }
+
+  try {
+    const res = await fetch(`/api/runs/${encodeURIComponent(runName)}/explain/gradcam`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ image_path: imagePath, class_index: classIndex }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      throw new Error(err.detail || res.statusText);
+    }
+    const { heatmap_b64 } = await res.json();
+    const heatSrc = `data:image/png;base64,${heatmap_b64}`;
+
+    figure.dataset.heatmap = heatSrc;
+    img.src = heatSrc;
+    img.onclick = () => openModal(heatSrc);
+    btn.textContent = 'Original';
+    btn.disabled = false;
+    figure.dataset.explained = '1';
+  } catch (e) {
+    btn.textContent = 'Explain';
+    btn.disabled = false;
+    const existing = figure.querySelector('.explain-error');
+    if (existing) existing.remove();
+    figure.insertAdjacentHTML('beforeend', `<small class="explain-error">${escHtml(e.message)}</small>`);
+  }
 }
 
 function imgPath(path) {


### PR DESCRIPTION
## Summary

- **Resume training fix:** `--resume best.keras` (or any checkpoint with no epoch number in the filename) no longer restarts from epoch 0. The epoch count is now read from `cfg.run.epochs_run` stored in the loaded config, with the filename regex kept as a fallback. The CSV training log is correctly appended rather than overwritten.
- **Grad-CAM explanations:** Each thumbnail in the confusion-matrix gallery now has an **Explain** button. Clicking it fetches a Grad-CAM heatmap from the new `/api/runs/{name}/explain/gradcam` endpoint and overlays it on the image. Clicking again reverts to the original (heatmap is cached per thumbnail so subsequent toggles are instant).
- **Docs:** Added a "Two-phase training" section to `README.md` and updated the `--resume` hint in `helper.sh`.

## Test plan

- [x] Two-phase training: phase 1 → 30 epochs, phase 2 `--from ... --resume best.keras --epochs 50` — verify starts at epoch 30 and CSV is appended
- [x] Interrupt resume: interrupt mid-run, resume from `interrupt_epochNNN.keras` — verify correct start epoch
- [x] WebUI: open a run's confusion matrix, click a cell, click **Explain** on a thumbnail — heatmap should appear; click again to revert
- [x] WebUI: verify toggle is instant on second click (cached heatmap)
- [x] WebUI: verify error message shown if Grad-CAM fails (no checkpoint, bad class index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)