### PR TITLE
refactor: rename Predict page to Inference in web UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ gpu-linux = [
 web = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
+    "python-multipart>=0.0.9",
 ]
 export = [
     "tf2onnx==1.17.0",

--- a/src/cvbench/augmentations/registry.py
+++ b/src/cvbench/augmentations/registry.py
@@ -1,0 +1,156 @@
+"""Augmentation registry — builds UI parameter schemas from function signatures.
+
+Design rationale
+----------------
+`inspect` extracts parameter names, type annotations, and default values directly
+from each aug_* function.  The registry stores *only* what introspection cannot
+provide: numeric ranges (min/max/step) and string option lists (choices).
+
+Computation modules (blur.py, noise.py, …) remain pure — no UI concepts bleed in.
+To add a new augmentation to the UI: write the function, add one entry to _RANGES.
+
+Parameters always excluded from the UI schema:
+    img   – implicit array input
+    seed  – internal randomness; the UI never exposes a seed (each Run is a fresh draw)
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+
+# ── Range / option metadata ───────────────────────────────────────────────────
+# Keys are aug_* function names.  Values are per-parameter dicts containing
+# only the fields that cannot be read from the function signature:
+#   min, max, step  – for numeric (int / float) params
+#   choices         – for str params with a fixed option set
+#   label           – human-readable augmentation name shown in the UI
+#   default         – fallback only when the function signature has no default value
+
+_RANGES: dict[str, dict] = {
+    "aug_blur": {
+        "label": "Gaussian Blur",
+        "params": {"radius": {"min": 0.5, "max": 15.0, "step": 0.5, "default": 3.0}},
+    },
+    "aug_salt_pepper": {
+        "label": "Salt & Pepper Noise",
+        "params": {"density": {"min": 0.0, "max": 0.5, "step": 0.01, "default": 0.05}},
+    },
+    "aug_gamma": {
+        "label": "Gamma Correction",
+        "params": {"gamma": {"min": 0.1, "max": 3.0, "step": 0.1, "default": 1.0}},
+    },
+    "aug_fog": {
+        "label": "Fog / Haze",
+        "params": {"strength": {"min": 0.0, "max": 1.0, "step": 0.05, "default": 0.3}},
+    },
+    "aug_lines_h": {
+        "label": "Horizontal Lines",
+        "params": {
+            "n_lines":    {"min": 1, "max": 20,  "step": 1},
+            "width":      {"min": 1, "max": 10,  "step": 1},
+            "brightness": {"min": 0, "max": 255, "step": 5},
+        },
+    },
+    "aug_lines_v": {
+        "label": "Vertical Lines",
+        "params": {
+            "n_lines":    {"min": 1, "max": 20,  "step": 1},
+            "width":      {"min": 1, "max": 10,  "step": 1},
+            "brightness": {"min": 0, "max": 255, "step": 5},
+        },
+    },
+    "aug_fade_horizontal": {
+        "label": "Horizontal Fade",
+        "params": {
+            "fade_to":  {"min": 0,   "max": 255, "step": 5},
+            "side":     {"choices": ["left", "right", "both"]},
+            "strength": {"min": 0.0, "max": 1.0, "step": 0.05},
+        },
+    },
+    "aug_fade_vertical": {
+        "label": "Vertical Fade",
+        "params": {
+            "fade_to":  {"min": 0,   "max": 255, "step": 5},
+            "side":     {"choices": ["top", "bottom", "both"]},
+            "strength": {"min": 0.0, "max": 1.0, "step": 0.05},
+        },
+    },
+    "aug_brighten_edges_h": {
+        "label": "Brighten Edges H",
+        "params": {
+            "fade_to":       {"min": 0,    "max": 255, "step": 5},
+            "strength":      {"min": 0.0,  "max": 1.0, "step": 0.05},
+            "edge_fraction": {"min": 0.05, "max": 0.5, "step": 0.05},
+        },
+    },
+    "aug_brighten_edges_v": {
+        "label": "Brighten Edges V",
+        "params": {
+            "fade_to":       {"min": 0,    "max": 255, "step": 5},
+            "strength":      {"min": 0.0,  "max": 1.0, "step": 0.05},
+            "edge_fraction": {"min": 0.05, "max": 0.5, "step": 0.05},
+        },
+    },
+    "aug_random_profile_h": {
+        "label": "Random Profile H",
+        "params": {
+            "n_changes": {"min": 1, "max": 10,  "step": 1},
+            "max_delta": {"min": 5, "max": 120, "step": 5},
+        },
+    },
+    "aug_random_profile_v": {
+        "label": "Random Profile V",
+        "params": {
+            "n_changes": {"min": 1, "max": 10,  "step": 1},
+            "max_delta": {"min": 5, "max": 120, "step": 5},
+        },
+    },
+}
+
+_SKIP = {"img", "seed"}
+
+
+def get_schema() -> list[dict]:
+    """Return UI-ready parameter schemas for all registered augmentations.
+
+    Merges live function introspection (names, types, defaults) with the range
+    metadata in _RANGES.  The result is a JSON-serialisable list consumed by
+    GET /api/augmentations.
+    """
+    import cvbench.augmentations as aug_mod
+
+    result = []
+    for func_name, meta in _RANGES.items():
+        fn = getattr(aug_mod, func_name, None)
+        if fn is None:
+            continue
+
+        sig = inspect.signature(fn)
+        params: list[dict[str, Any]] = []
+
+        for pname, p in sig.parameters.items():
+            if pname in _SKIP:
+                continue
+
+            range_meta = meta["params"].get(pname, {})
+            has_default = p.default is not inspect.Parameter.empty
+            default = p.default if has_default else range_meta.get("default")
+
+            if "choices" in range_meta:
+                ptype = "choice"
+            elif p.annotation is int or (has_default and isinstance(p.default, int)):
+                ptype = "int"
+            else:
+                ptype = "float"
+
+            entry: dict[str, Any] = {"name": pname, "type": ptype, "default": default}
+            for k, v in range_meta.items():
+                if k != "default":   # default already resolved above
+                    entry[k] = v
+            params.append(entry)
+
+        result.append({"name": func_name, "label": meta["label"], "params": params})
+
+    return result

--- a/src/cvbench/services/gradcam.py
+++ b/src/cvbench/services/gradcam.py
@@ -16,6 +16,20 @@ import io
 import numpy as np
 
 
+def compute_gradcam_from_bytes(checkpoint: str, image_bytes: bytes, class_index: int) -> str:
+    """Like compute_gradcam but accepts raw image bytes instead of a file path."""
+    import os
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        f.write(image_bytes)
+        tmp_path = f.name
+    try:
+        return compute_gradcam(checkpoint, tmp_path, class_index)
+    finally:
+        os.unlink(tmp_path)
+
+
 def compute_gradcam(checkpoint: str, image_path: str, class_index: int) -> str:
     """Return a base64 PNG of the Grad-CAM heatmap blended onto the original image.
 

--- a/src/cvbench/services/prediction.py
+++ b/src/cvbench/services/prediction.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import io
 from pathlib import Path
 
 import keras
@@ -42,6 +44,124 @@ def run_prediction(checkpoint: str, input_path: str) -> list[dict]:
         })
 
     return results
+
+
+def predict_image(run_name: str, image_bytes: bytes) -> dict:
+    """Run inference on a single image supplied as raw bytes.
+
+    Returns:
+        class_name  – predicted class label
+        class_index – predicted class index
+        confidence  – probability of the top class
+        top_k       – list of {class_name, confidence} sorted by confidence desc
+    """
+    from cvbench.core.runs import resolve_run_dir
+    from cvbench.core.config import load_config
+
+    run_dir = resolve_run_dir(run_name)
+    cfg = load_config(run_dir)
+    class_names = cfg.data.classes
+
+    checkpoint = _find_checkpoint(Path(run_dir))
+    if checkpoint is None:
+        raise ValueError(f"No model checkpoint found for run '{run_name}'")
+
+    model = keras.saving.load_model(str(checkpoint))
+    size = model.input_shape[1]
+
+    arr = _bytes_to_input(image_bytes, size)
+    probs = model.predict(arr, verbose=0)[0]
+
+    return _build_result(probs, class_names)
+
+
+def predict_augmented(run_name: str, image_bytes: bytes, augmentations: list[dict]) -> dict:
+    """Apply a sequence of augmentations to an image then run inference.
+
+    Args:
+        run_name:     experiment run name (used to locate checkpoint + class list)
+        image_bytes:  raw image bytes (any PIL-readable format)
+        augmentations: list of {name: str, params: dict} applied in order
+
+    Returns same keys as predict_image plus:
+        augmented_image_b64 – base64 PNG of the augmented image
+    """
+    import cvbench.augmentations as aug_mod
+    from cvbench.core.runs import resolve_run_dir
+    from cvbench.core.config import load_config
+
+    run_dir = resolve_run_dir(run_name)
+    cfg = load_config(run_dir)
+    class_names = cfg.data.classes
+
+    checkpoint = _find_checkpoint(Path(run_dir))
+    if checkpoint is None:
+        raise ValueError(f"No model checkpoint found for run '{run_name}'")
+
+    model = keras.saving.load_model(str(checkpoint))
+    size = model.input_shape[1]
+
+    img_arr = _bytes_to_numpy(image_bytes, size)  # (H, W, C) uint8
+
+    for aug in augmentations:
+        fn = getattr(aug_mod, aug["name"], None)
+        if fn is None:
+            raise ValueError(f"Unknown augmentation: {aug['name']}")
+        img_arr = fn(img_arr, **aug.get("params", {}))
+
+    augmented_b64 = _numpy_to_base64_png(img_arr)
+
+    arr = img_arr.astype(np.float32)[None]  # (1, H, W, C)
+    probs = model.predict(arr, verbose=0)[0]
+
+    result = _build_result(probs, class_names)
+    result["augmented_image_b64"] = augmented_b64
+    return result
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _build_result(probs: np.ndarray, class_names: list[str]) -> dict:
+    top_k = sorted(
+        [{"class_name": class_names[i], "confidence": float(probs[i])} for i in range(len(probs))],
+        key=lambda x: -x["confidence"],
+    )
+    return {
+        "class_name": top_k[0]["class_name"],
+        "class_index": int(np.argmax(probs)),
+        "confidence": top_k[0]["confidence"],
+        "top_k": top_k,
+    }
+
+
+def _bytes_to_input(image_bytes: bytes, size: int) -> np.ndarray:
+    """Load image bytes → (1, H, W, C) float32 array ready for model.predict()."""
+    from PIL import Image
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB").resize((size, size))
+    return np.array(img, dtype=np.float32)[None]
+
+
+def _bytes_to_numpy(image_bytes: bytes, size: int) -> np.ndarray:
+    """Load image bytes → (H, W, C) uint8 numpy array."""
+    from PIL import Image
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGB").resize((size, size))
+    return np.array(img, dtype=np.uint8)
+
+
+def _numpy_to_base64_png(arr: np.ndarray) -> str:
+    """Convert (H, W, C) uint8 numpy array → base64-encoded PNG string."""
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.fromarray(arr.astype(np.uint8)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _find_checkpoint(run_dir: Path) -> Path | None:
+    for pattern in ("best_model.keras", "*.keras", "best_model.h5", "*.h5"):
+        matches = sorted(run_dir.glob(pattern))
+        if matches:
+            return matches[0]
+    return None
 
 
 def _collect_images(path: str) -> list[str]:

--- a/src/cvbench/web/api/__init__.py
+++ b/src/cvbench/web/api/__init__.py
@@ -16,13 +16,13 @@ it here.
 
 try:
     from fastapi import APIRouter
-    from cvbench.web.api import runs, explain
+    from cvbench.web.api import runs, explain, prediction
 
     router = APIRouter()
-    router.include_router(runs.router,    tags=["runs"])
-    router.include_router(explain.router, tags=["explain"])
+    router.include_router(runs.router,        tags=["runs"])
+    router.include_router(explain.router,     tags=["explain"])
+    router.include_router(prediction.router,  tags=["prediction"])
     # router.include_router(training.router,   tags=["training"])
     # router.include_router(evaluation.router, tags=["evaluation"])
-    # router.include_router(prediction.router, tags=["prediction"])
 except ImportError:
     router = None  # type: ignore[assignment]  # guarded in app.create_app()

--- a/src/cvbench/web/api/prediction.py
+++ b/src/cvbench/web/api/prediction.py
@@ -1,23 +1,92 @@
-"""Prediction API — single-image inference via file upload.
+"""Prediction API — single-image inference, augmentation, and XAI."""
 
-Planned endpoints
------------------
-    POST /api/predict    upload an image + specify a checkpoint → get predicted class + confidence
+from __future__ import annotations
 
-Each handler should call:
-    from cvbench.services.prediction import run_prediction
+import json
 
-The request body should be multipart/form-data:
-    - file:       the image to classify (UploadFile)
-    - checkpoint: path to the .keras model file
+from fastapi import APIRouter, Form, HTTPException, UploadFile, File
+from fastapi.responses import JSONResponse
 
-TODO: implement (tracked in a follow-up GitHub issue)
-"""
-
-from fastapi import APIRouter
+from cvbench.augmentations.registry import get_schema
+from cvbench.core.runs import resolve_run_dir
 
 router = APIRouter()
 
 
-# @router.post("/predict")
-# def predict(file: UploadFile, checkpoint: str): ...
+@router.get("/augmentations")
+def list_augmentations():
+    """Return UI parameter schemas for all registered augmentations."""
+    return get_schema()
+
+
+@router.post("/predict/single")
+async def predict_single(
+    file: UploadFile = File(...),
+    run: str = Form(...),
+):
+    """Run inference on an uploaded image using the checkpoint from the given run."""
+    image_bytes = await file.read()
+    try:
+        from cvbench.services.prediction import predict_image
+        result = predict_image(run, image_bytes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return JSONResponse(result)
+
+
+@router.post("/predict/augmented")
+async def predict_augmented(
+    file: UploadFile = File(...),
+    run: str = Form(...),
+    augmentations: str = Form(...),
+):
+    """Apply augmentations to an uploaded image then run inference.
+
+    `augmentations` is a JSON string: [{name: str, params: {…}}, …]
+    """
+    image_bytes = await file.read()
+    try:
+        aug_list = json.loads(augmentations)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="augmentations must be valid JSON")
+
+    try:
+        from cvbench.services.prediction import predict_augmented as _predict_augmented
+        result = _predict_augmented(run, image_bytes, aug_list)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return JSONResponse(result)
+
+
+@router.post("/predict/xai")
+async def predict_xai(
+    file: UploadFile = File(...),
+    run: str = Form(...),
+    class_index: int = Form(...),
+):
+    """Compute a Grad-CAM heatmap for an uploaded image."""
+    image_bytes = await file.read()
+
+    try:
+        run_dir = resolve_run_dir(run)
+    except Exception:
+        raise HTTPException(status_code=404, detail=f"Run '{run}' not found")
+
+    from pathlib import Path
+    from cvbench.web.api.explain import _find_checkpoint
+
+    checkpoint = _find_checkpoint(Path(run_dir))
+    if checkpoint is None:
+        raise HTTPException(status_code=404, detail="No model checkpoint found for this run")
+
+    try:
+        from cvbench.services.gradcam import compute_gradcam_from_bytes
+        heatmap_b64 = compute_gradcam_from_bytes(str(checkpoint), image_bytes, class_index)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    return JSONResponse({"heatmap_b64": heatmap_b64})

--- a/src/cvbench/web/static/css/style.css
+++ b/src/cvbench/web/static/css/style.css
@@ -66,6 +66,7 @@ body { margin: 0; }
   flex: 1;
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
   gap: 1px;
 }
 
@@ -495,6 +496,356 @@ body { margin: 0; }
 }
 
 [data-theme="dark"] .error-msg { background: #450a0a; color: #fca5a5; }
+
+/* ── Predict page layout ───────────────────────────────────────────────────── */
+
+.predict-layout {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .predict-layout { grid-template-columns: 1fr; }
+}
+
+.predict-left {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: sticky;
+  top: 1.5rem;
+}
+
+.predict-section { display: flex; flex-direction: column; gap: 0.375rem; }
+
+/* ── Drop zone ─────────────────────────────────────────────────────────────── */
+
+.drop-zone {
+  border: 2px dashed var(--pico-card-border-color, var(--card-border-color));
+  border-radius: 8px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  min-height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.drop-zone:hover,
+.drop-zone.drag-over {
+  border-color: var(--brand-color);
+  background: rgba(99,102,241,0.04);
+}
+
+.drop-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-size: 0.769rem;
+  text-align: center;
+  pointer-events: none;
+}
+
+.drop-preview {
+  max-height: 90px;
+  max-width: 100%;
+  border-radius: 5px;
+  object-fit: contain;
+  display: block;
+}
+
+.drop-filename {
+  font-size: 0.692rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  word-break: break-all;
+  max-width: 200px;
+}
+
+/* ── Augmentation panel ────────────────────────────────────────────────────── */
+
+.predict-aug-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.predict-add-btn {
+  font-size: 0.769rem !important;
+  padding: 0.2rem 0.6rem !important;
+  margin: 0 !important;
+  line-height: 1.4 !important;
+}
+
+.aug-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 100;
+  background: var(--pico-card-background-color, var(--card-background-color));
+  border: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+  min-width: 180px;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 0.25rem 0;
+}
+
+.aug-dropdown-item {
+  padding: 0.35rem 0.875rem;
+  font-size: 0.815rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.aug-dropdown-item:hover {
+  background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color));
+}
+
+#aug-stack { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.25rem; }
+
+.aug-empty {
+  font-size: 0.769rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  margin: 0.25rem 0 0;
+}
+
+.aug-card {
+  background: var(--pico-card-background-color, var(--card-background-color));
+  border: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem 0.6rem;
+}
+
+.aug-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+}
+
+.aug-card-label {
+  font-size: 0.815rem;
+  font-weight: 600;
+}
+
+.aug-remove-btn {
+  background: none;
+  border: none;
+  color: var(--pico-muted-color, var(--muted-color));
+  cursor: pointer;
+  font-size: 0.769rem;
+  padding: 0;
+  line-height: 1;
+  box-shadow: none;
+}
+
+.aug-remove-btn:hover { color: #dc2626; }
+
+.aug-param-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 36px;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.2rem;
+}
+
+.aug-param-label {
+  font-size: 0.692rem;
+  color: var(--pico-muted-color, var(--muted-color));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.aug-param-slider {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  height: 4px;
+  accent-color: var(--brand-color);
+  cursor: pointer;
+}
+
+.aug-param-val {
+  font-size: 0.692rem;
+  text-align: right;
+  color: var(--pico-color, var(--color));
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.aug-param-select {
+  grid-column: 2 / 4;
+  font-size: 0.769rem !important;
+  padding: 0.2rem 0.4rem !important;
+  margin: 0 !important;
+  height: auto !important;
+}
+
+/* ── Run button ────────────────────────────────────────────────────────────── */
+
+.predict-run-btn {
+  width: 100%;
+  margin: 0;
+  font-size: 0.846rem;
+}
+
+/* ── Right panel / results ─────────────────────────────────────────────────── */
+
+.predict-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 300px;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-size: 0.846rem;
+  text-align: center;
+}
+
+.predict-results-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.predict-results-grid.has-aug {
+  grid-template-columns: 1fr 1fr;
+}
+
+@media (max-width: 700px) {
+  .predict-results-grid.has-aug { grid-template-columns: 1fr; }
+}
+
+.predict-result-panel {
+  background: var(--pico-card-background-color, var(--card-background-color));
+  border: 1px solid var(--pico-card-border-color, var(--card-border-color));
+  border-radius: 8px;
+  padding: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.predict-result-panel.result-flipped {
+  border-color: #f59e0b;
+}
+
+.flip-badge {
+  display: inline-block;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.615rem;
+  font-weight: 700;
+  padding: 0.1em 0.45em;
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  vertical-align: middle;
+  margin-left: 0.3rem;
+}
+
+[data-theme="dark"] .flip-badge { background: #3d2600; color: #fbbf24; }
+
+.result-image-wrap {
+  display: inline-block;
+  border-radius: 5px;
+  overflow: hidden;
+  background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color));
+}
+
+.result-image {
+  display: block;
+  max-width: min(100%, 320px);
+  max-height: 320px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  cursor: zoom-in;
+}
+
+/* ── Augmented panel processing state ─────────────────────────────────────── */
+
+.aug-processing-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 160px;
+  color: var(--pico-muted-color, var(--muted-color));
+  font-size: 0.846rem;
+}
+
+.aug-processing-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--pico-card-border-color, var(--card-border-color));
+  border-top-color: var(--brand-color);
+  border-radius: 50%;
+  animation: aug-spin 0.7s linear infinite;
+}
+
+@keyframes aug-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Top-K confidence bars ─────────────────────────────────────────────────── */
+
+.result-topk { display: flex; flex-direction: column; gap: 0.3rem; }
+
+.topk-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 42px;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.topk-label {
+  font-size: 0.769rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.topk-label.topk-top { font-weight: 700; }
+
+.topk-bar-wrap {
+  height: 8px;
+  background: var(--pico-card-sectioning-background-color, var(--card-sectionning-background-color));
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.topk-bar {
+  height: 100%;
+  background: rgba(99,102,241,0.4);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.topk-bar.topk-bar-top { background: var(--brand-color); }
+
+.topk-pct {
+  font-size: 0.692rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--pico-muted-color, var(--muted-color));
+}
+
+.result-explain-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
 
 /* ── Modal ─────────────────────────────────────────────────────────────────── */
 

--- a/src/cvbench/web/static/css/style.css
+++ b/src/cvbench/web/static/css/style.css
@@ -499,7 +499,7 @@ body { margin: 0; }
 
 /* ── Predict page layout ───────────────────────────────────────────────────── */
 
-.predict-layout {
+.inference-layout {
   display: grid;
   grid-template-columns: 360px 1fr;
   gap: 1.25rem;
@@ -507,10 +507,10 @@ body { margin: 0; }
 }
 
 @media (max-width: 900px) {
-  .predict-layout { grid-template-columns: 1fr; }
+  .inference-layout { grid-template-columns: 1fr; }
 }
 
-.predict-left {
+.inference-left {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -518,7 +518,7 @@ body { margin: 0; }
   top: 1.5rem;
 }
 
-.predict-section { display: flex; flex-direction: column; gap: 0.375rem; }
+.inference-section { display: flex; flex-direction: column; gap: 0.375rem; }
 
 /* ── Drop zone ─────────────────────────────────────────────────────────────── */
 
@@ -568,13 +568,13 @@ body { margin: 0; }
 
 /* ── Augmentation panel ────────────────────────────────────────────────────── */
 
-.predict-aug-header {
+.inference-aug-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
 }
 
-.predict-add-btn {
+.inference-add-btn {
   font-size: 0.769rem !important;
   padding: 0.2rem 0.6rem !important;
   margin: 0 !important;
@@ -690,7 +690,7 @@ body { margin: 0; }
 
 /* ── Run button ────────────────────────────────────────────────────────────── */
 
-.predict-run-btn {
+.inference-run-btn {
   width: 100%;
   margin: 0;
   font-size: 0.846rem;
@@ -698,7 +698,7 @@ body { margin: 0; }
 
 /* ── Right panel / results ─────────────────────────────────────────────────── */
 
-.predict-placeholder {
+.inference-placeholder {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -710,21 +710,21 @@ body { margin: 0; }
   text-align: center;
 }
 
-.predict-results-grid {
+.inference-results-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
 }
 
-.predict-results-grid.has-aug {
+.inference-results-grid.has-aug {
   grid-template-columns: 1fr 1fr;
 }
 
 @media (max-width: 700px) {
-  .predict-results-grid.has-aug { grid-template-columns: 1fr; }
+  .inference-results-grid.has-aug { grid-template-columns: 1fr; }
 }
 
-.predict-result-panel {
+.inference-result-panel {
   background: var(--pico-card-background-color, var(--card-background-color));
   border: 1px solid var(--pico-card-border-color, var(--card-border-color));
   border-radius: 8px;
@@ -734,7 +734,7 @@ body { margin: 0; }
   gap: 0.625rem;
 }
 
-.predict-result-panel.result-flipped {
+.inference-result-panel.result-flipped {
   border-color: #f59e0b;
 }
 

--- a/src/cvbench/web/static/index.html
+++ b/src/cvbench/web/static/index.html
@@ -25,9 +25,9 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
           Experiments
         </a>
-        <a href="#/predict" id="nav-predict" class="nav-link" onclick="setActive('nav-predict')">
+        <a href="#/inference" id="nav-inference" class="nav-link" onclick="setActive('nav-inference')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-          Predict
+          Inference
         </a>
       </nav>
 

--- a/src/cvbench/web/static/index.html
+++ b/src/cvbench/web/static/index.html
@@ -25,6 +25,10 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
           Experiments
         </a>
+        <a href="#/predict" id="nav-predict" class="nav-link" onclick="setActive('nav-predict')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+          Predict
+        </a>
       </nav>
 
       <div class="sidebar-footer">

--- a/src/cvbench/web/static/js/app.js
+++ b/src/cvbench/web/static/js/app.js
@@ -15,6 +15,8 @@ function route() {
     showRunsList();
   } else if (hash.startsWith('#/runs/')) {
     showRunDetail(decodeURIComponent(hash.slice(7)));
+  } else if (hash === '#/predict') {
+    showPredict();
   }
 }
 
@@ -609,4 +611,467 @@ function escHtml(str) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+/* ── Predict page ──────────────────────────────────────────────────────────── */
+
+let _predictRuns       = [];
+let _predictAugSchema  = [];
+let _predictFile       = null;   // File object from drop / browse
+let _predictAugments   = [];     // [{id, name, label, params: {name: value}}]
+let _predictAugCounter = 0;
+let _predictOrigResult = null;   // last original prediction result
+let _predictAugResult  = null;   // last augmented prediction result
+let _predictOrigKey    = null;   // "run::filename::size" — cache key for orig result
+
+async function showPredict() {
+  setActive('nav-predict');
+  const page = document.getElementById('page');
+  page.innerHTML = '<p aria-busy="true">Loading…</p>';
+
+  try {
+    [_predictRuns, _predictAugSchema] = await Promise.all([
+      api('/runs'),
+      api('/augmentations'),
+    ]);
+  } catch (e) {
+    page.innerHTML = `<p class="error-msg">Failed to load: ${e.message}</p>`;
+    return;
+  }
+
+  _predictFile       = null;
+  _predictAugments   = [];
+  _predictAugCounter = 0;
+  _predictOrigResult = null;
+  _predictAugResult  = null;
+
+  page.innerHTML = buildPredictPage();
+  _initDropZone();
+}
+
+function buildPredictPage() {
+  const runOptions = _predictRuns.length
+    ? _predictRuns.map(r =>
+        `<option value="${escHtml(r.name)}">${escHtml(r.name)} (${escHtml(r.backbone)}, ${fmtAcc(r.val_accuracy)})</option>`
+      ).join('')
+    : '<option value="">No runs available</option>';
+
+  return `
+    <div class="page-header"><h2>Predict</h2></div>
+    <div class="predict-layout">
+
+      <!-- LEFT PANEL -->
+      <div class="predict-left">
+
+        <div class="predict-section">
+          <p class="section-label">Model</p>
+          <select id="predict-run-select" style="margin:0">
+            ${runOptions}
+          </select>
+        </div>
+
+        <div class="predict-section">
+          <p class="section-label">Image</p>
+          <div class="drop-zone" id="predict-drop-zone" onclick="document.getElementById('predict-file-input').click()">
+            <div class="drop-inner" id="drop-inner">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                <polyline points="17 8 12 3 7 8"/>
+                <line x1="12" y1="3" x2="12" y2="15"/>
+              </svg>
+              <span>Drop image or click to browse</span>
+            </div>
+            <input type="file" id="predict-file-input" accept="image/*" style="display:none"
+                   onchange="onPredictFileSelected(this.files[0])">
+          </div>
+        </div>
+
+        <div class="predict-section">
+          <div class="predict-aug-header">
+            <p class="section-label" style="margin:0">Augmentations</p>
+            <div style="position:relative">
+              <button class="predict-add-btn outline" onclick="toggleAugDropdown(event)">+ Add</button>
+              <div class="aug-dropdown" id="aug-dropdown" style="display:none">
+                ${_predictAugSchema.map(a =>
+                  `<div class="aug-dropdown-item" onclick="addAugmentation('${escHtml(a.name)}')">${escHtml(a.label)}</div>`
+                ).join('')}
+              </div>
+            </div>
+          </div>
+          <div id="aug-stack"></div>
+        </div>
+
+        <button id="predict-run-btn" class="predict-run-btn" onclick="runPrediction()" disabled>
+          ▶ Run
+        </button>
+
+      </div>
+
+      <!-- RIGHT PANEL -->
+      <div class="predict-right" id="predict-right">
+        <div class="predict-placeholder">
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" opacity="0.3" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>
+            <polyline points="21 15 16 10 5 21"/>
+          </svg>
+          <p>Drop an image and press Run to see predictions</p>
+        </div>
+      </div>
+
+    </div>
+  `;
+}
+
+/* ── Drop zone ─────────────────────────────────────────────────────────────── */
+
+function _initDropZone() {
+  const zone = document.getElementById('predict-drop-zone');
+  if (!zone) return;
+
+  zone.addEventListener('dragover', e => { e.preventDefault(); zone.classList.add('drag-over'); });
+  zone.addEventListener('dragleave', ()  => zone.classList.remove('drag-over'));
+  zone.addEventListener('drop', e => {
+    e.preventDefault();
+    zone.classList.remove('drag-over');
+    const f = e.dataTransfer.files[0];
+    if (f) onPredictFileSelected(f);
+  });
+}
+
+function onPredictFileSelected(file) {
+  if (!file) return;
+  _predictFile = file;
+
+  const reader = new FileReader();
+  reader.onload = ev => {
+    const inner = document.getElementById('drop-inner');
+    if (inner) inner.innerHTML = `
+      <img src="${ev.target.result}" class="drop-preview" alt="preview">
+      <span class="drop-filename">${escHtml(file.name)}</span>
+    `;
+  };
+  reader.readAsDataURL(file);
+
+  const btn = document.getElementById('predict-run-btn');
+  if (btn) btn.disabled = false;
+
+  // Clear previous results — new file invalidates the orig cache
+  _predictOrigResult = null;
+  _predictAugResult  = null;
+  _predictOrigKey    = null;
+  _renderRight();
+}
+
+/* ── Augmentation stack ────────────────────────────────────────────────────── */
+
+function toggleAugDropdown(e) {
+  e.stopPropagation();
+  const dd = document.getElementById('aug-dropdown');
+  if (!dd) return;
+  dd.style.display = dd.style.display === 'none' ? 'block' : 'none';
+  const close = () => { dd.style.display = 'none'; document.removeEventListener('click', close); };
+  if (dd.style.display === 'block') setTimeout(() => document.addEventListener('click', close), 0);
+}
+
+function addAugmentation(name) {
+  const schema = _predictAugSchema.find(a => a.name === name);
+  if (!schema) return;
+
+  const id = ++_predictAugCounter;
+  const params = {};
+  schema.params.forEach(p => { params[p.name] = p.default; });
+  _predictAugments.push({ id, name, label: schema.label, params });
+  _renderAugStack();
+}
+
+function removeAugmentation(id) {
+  _predictAugments = _predictAugments.filter(a => a.id !== id);
+  _renderAugStack();
+}
+
+function updateAugParam(id, paramName, value) {
+  const aug = _predictAugments.find(a => a.id === id);
+  if (!aug) return;
+  const schema = _predictAugSchema.find(a => a.name === aug.name);
+  const pSchema = schema?.params.find(p => p.name === paramName);
+  aug.params[paramName] = pSchema?.type === 'int' ? parseInt(value, 10) : pSchema?.type === 'float' ? parseFloat(value) : value;
+  // Update displayed value label without full re-render
+  const label = document.getElementById(`pval-${id}-${paramName}`);
+  if (label) label.textContent = aug.params[paramName];
+}
+
+function _renderAugStack() {
+  const stack = document.getElementById('aug-stack');
+  if (!stack) return;
+
+  if (_predictAugments.length === 0) {
+    stack.innerHTML = '<p class="aug-empty">No augmentations added.</p>';
+    return;
+  }
+
+  stack.innerHTML = _predictAugments.map(aug => {
+    const schema = _predictAugSchema.find(a => a.name === aug.name);
+    const controls = (schema?.params || []).map(p => {
+      const val = aug.params[p.name];
+      if (p.type === 'choice') {
+        const opts = p.choices.map(c => `<option value="${c}" ${c === val ? 'selected' : ''}>${c}</option>`).join('');
+        return `
+          <div class="aug-param-row">
+            <label class="aug-param-label">${p.name}</label>
+            <select class="aug-param-select"
+                    onchange="updateAugParam(${aug.id}, '${p.name}', this.value)">
+              ${opts}
+            </select>
+          </div>
+        `;
+      }
+      return `
+        <div class="aug-param-row">
+          <label class="aug-param-label">${p.name}</label>
+          <input type="range" class="aug-param-slider"
+                 min="${p.min}" max="${p.max}" step="${p.step}" value="${val}"
+                 oninput="updateAugParam(${aug.id}, '${p.name}', this.value)">
+          <span class="aug-param-val" id="pval-${aug.id}-${p.name}">${val}</span>
+        </div>
+      `;
+    }).join('');
+
+    return `
+      <div class="aug-card">
+        <div class="aug-card-header">
+          <span class="aug-card-label">${escHtml(aug.label)}</span>
+          <button class="aug-remove-btn" title="Remove" onclick="removeAugmentation(${aug.id})">✕</button>
+        </div>
+        ${controls}
+      </div>
+    `;
+  }).join('');
+}
+
+/* ── Run prediction ────────────────────────────────────────────────────────── */
+
+async function runPrediction() {
+  if (!_predictFile) return;
+
+  const run = document.getElementById('predict-run-select')?.value;
+  if (!run) return;
+
+  const btn = document.getElementById('predict-run-btn');
+  if (btn) { btn.disabled = true; btn.textContent = '…'; }
+
+  const hasAug = _predictAugments.length > 0;
+  const origKey = `${run}::${_predictFile.name}::${_predictFile.size}`;
+  const origCached = _predictOrigResult && _predictOrigKey === origKey;
+
+  _predictAugResult = null;
+  _renderPendingGrid(hasAug, origCached);
+
+  try {
+    if (!origCached) {
+      _predictOrigResult = null;
+      const fd = new FormData();
+      fd.append('file', _predictFile);
+      fd.append('run', run);
+
+      const origRes = await fetch('/api/predict/single', { method: 'POST', body: fd });
+      if (!origRes.ok) {
+        const err = await origRes.json().catch(() => ({ detail: origRes.statusText }));
+        throw new Error(err.detail || origRes.statusText);
+      }
+      _predictOrigResult = await origRes.json();
+      _predictOrigKey    = origKey;
+      _updateOrigPanel();
+    }
+
+    if (hasAug) {
+      const augPayload = _predictAugments.map(a => ({ name: a.name, params: a.params }));
+      const fd2 = new FormData();
+      fd2.append('file', _predictFile);
+      fd2.append('run', run);
+      fd2.append('augmentations', JSON.stringify(augPayload));
+
+      const augRes = await fetch('/api/predict/augmented', { method: 'POST', body: fd2 });
+      if (!augRes.ok) {
+        const err = await augRes.json().catch(() => ({ detail: augRes.statusText }));
+        throw new Error(err.detail || augRes.statusText);
+      }
+      _predictAugResult = await augRes.json();
+      _updateAugPanel();
+    }
+  } catch (e) {
+    document.getElementById('predict-right').innerHTML =
+      `<p class="error-msg">${escHtml(e.message)}</p>`;
+    if (btn) { btn.disabled = false; btn.textContent = '▶ Run'; }
+    return;
+  }
+
+  if (btn) { btn.disabled = false; btn.textContent = '▶ Run'; }
+}
+
+/* ── Right panel rendering ─────────────────────────────────────────────────── */
+
+function _renderRight() {
+  const right = document.getElementById('predict-right');
+  if (!right) return;
+  right.innerHTML = `
+    <div class="predict-placeholder">
+      <p>Drop an image and press Run to see predictions</p>
+    </div>`;
+}
+
+function _pendingSlot(label) {
+  return `
+    <div class="predict-result-panel">
+      <p class="section-label">${label}</p>
+      <div class="aug-processing-placeholder">
+        <div class="aug-processing-spinner"></div>
+        <span>Processing…</span>
+      </div>
+    </div>`;
+}
+
+function _renderPendingGrid(hasAug, origCached) {
+  const right = document.getElementById('predict-right');
+  if (!right) return;
+  const origContent = origCached
+    ? `<div class="predict-result-panel"><p class="section-label">Original</p>${buildResultPanel('orig', _predictOrigResult, null)}</div>`
+    : _pendingSlot('Original');
+  right.innerHTML = `
+    <div class="predict-results-grid ${hasAug ? 'has-aug' : ''}">
+      <div id="predict-orig-slot">${origContent}</div>
+      ${hasAug ? `<div id="predict-aug-slot">${_pendingSlot('Augmented')}</div>` : '<div id="predict-aug-slot"></div>'}
+    </div>`;
+}
+
+function _updateOrigPanel() {
+  const slot = document.getElementById('predict-orig-slot');
+  if (!slot || !_predictOrigResult) return;
+  slot.innerHTML = `
+    <div class="predict-result-panel">
+      <p class="section-label">Original</p>
+      ${buildResultPanel('orig', _predictOrigResult, null)}
+    </div>`;
+}
+
+function _updateAugPanel() {
+  if (!_predictAugResult) return;
+  const grid = document.querySelector('.predict-results-grid');
+  if (grid) grid.classList.add('has-aug');
+  const flipped = _predictAugResult.class_name !== _predictOrigResult.class_name;
+  const slot = document.getElementById('predict-aug-slot');
+  if (!slot) return;
+  slot.innerHTML = `
+    <div class="predict-result-panel ${flipped ? 'result-flipped' : ''}">
+      <p class="section-label">
+        Augmented
+        ${flipped ? '<span class="flip-badge">⚠ prediction changed</span>' : ''}
+      </p>
+      ${buildResultPanel('aug', _predictAugResult, _predictAugResult.augmented_image_b64)}
+    </div>`;
+}
+
+function buildResultPanel(panelId, result, augImageB64) {
+  const topK = (result.top_k || []).slice(0, 5);
+  const maxConf = topK.length ? topK[0].confidence : 1;
+
+  const bars = topK.map((item, i) => {
+    const pct = (item.confidence / maxConf * 100).toFixed(1);
+    const isTop = i === 0;
+    return `
+      <div class="topk-row">
+        <span class="topk-label ${isTop ? 'topk-top' : ''}">${escHtml(item.class_name)}</span>
+        <div class="topk-bar-wrap">
+          <div class="topk-bar ${isTop ? 'topk-bar-top' : ''}" style="width:${pct}%"></div>
+        </div>
+        <span class="topk-pct">${(item.confidence * 100).toFixed(1)}%</span>
+      </div>
+    `;
+  }).join('');
+
+  const imgSrc = augImageB64
+    ? `data:image/png;base64,${augImageB64}`
+    : (_predictFile ? URL.createObjectURL(_predictFile) : '');
+
+  return `
+    <div class="result-image-wrap">
+      <img src="${imgSrc}" class="result-image" alt="input image"
+           onclick="openModal('${imgSrc}')" id="result-img-${panelId}">
+    </div>
+    <div class="result-topk">${bars}</div>
+    <div class="result-explain-row">
+      <button class="explain-btn outline"
+              onclick="explainPrediction(event, '${panelId}', ${result.class_index})">
+        Explain
+      </button>
+      <span class="explain-error" id="explain-err-${panelId}"></span>
+    </div>
+  `;
+}
+
+/* ── XAI for predict page ──────────────────────────────────────────────────── */
+
+async function explainPrediction(event, panelId, classIndex) {
+  const btn = event.target;
+  const errEl = document.getElementById(`explain-err-${panelId}`);
+  const imgEl = document.getElementById(`result-img-${panelId}`);
+  if (!imgEl) return;
+
+  // Toggle: if heatmap is showing, revert to original
+  if (btn.dataset.explained === '1') {
+    imgEl.src = btn.dataset.origSrc;
+    imgEl.onclick = () => openModal(btn.dataset.origSrc);
+    btn.textContent = 'Explain';
+    btn.dataset.explained = '0';
+    return;
+  }
+  if (btn.dataset.heatmap) {
+    imgEl.src = btn.dataset.heatmap;
+    imgEl.onclick = () => openModal(btn.dataset.heatmap);
+    btn.textContent = 'Original';
+    btn.dataset.explained = '1';
+    return;
+  }
+
+  btn.dataset.origSrc = imgEl.src;
+  btn.textContent = '…';
+  btn.disabled = true;
+  if (errEl) errEl.textContent = '';
+
+  const run = document.getElementById('predict-run-select')?.value;
+  if (!run) { btn.textContent = 'Explain'; btn.disabled = false; return; }
+
+  // For the augmented panel, XAI runs on the augmented image bytes (base64 → Blob)
+  let fileToSend = _predictFile;
+  if (panelId === 'aug' && _predictAugResult?.augmented_image_b64) {
+    const binary = atob(_predictAugResult.augmented_image_b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    fileToSend = new Blob([bytes], { type: 'image/png' });
+  }
+
+  try {
+    const fd = new FormData();
+    fd.append('file', fileToSend, 'image.png');
+    fd.append('run', run);
+    fd.append('class_index', classIndex);
+
+    const res = await fetch('/api/predict/xai', { method: 'POST', body: fd });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      throw new Error(err.detail || res.statusText);
+    }
+    const { heatmap_b64 } = await res.json();
+    const heatSrc = `data:image/png;base64,${heatmap_b64}`;
+
+    btn.dataset.heatmap   = heatSrc;
+    btn.dataset.explained = '1';
+    imgEl.src = heatSrc;
+    imgEl.onclick = () => openModal(heatSrc);
+    btn.textContent = 'Original';
+    btn.disabled = false;
+  } catch (e) {
+    btn.textContent = 'Explain';
+    btn.disabled = false;
+    if (errEl) errEl.textContent = e.message;
+  }
 }

--- a/src/cvbench/web/static/js/app.js
+++ b/src/cvbench/web/static/js/app.js
@@ -15,8 +15,8 @@ function route() {
     showRunsList();
   } else if (hash.startsWith('#/runs/')) {
     showRunDetail(decodeURIComponent(hash.slice(7)));
-  } else if (hash === '#/predict') {
-    showPredict();
+  } else if (hash === '#/inference') {
+    showInference();
   }
 }
 
@@ -613,24 +613,24 @@ function escHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
-/* ── Predict page ──────────────────────────────────────────────────────────── */
+/* ── Inference page ──────────────────────────────────────────────────────────── */
 
-let _predictRuns       = [];
-let _predictAugSchema  = [];
-let _predictFile       = null;   // File object from drop / browse
-let _predictAugments   = [];     // [{id, name, label, params: {name: value}}]
-let _predictAugCounter = 0;
-let _predictOrigResult = null;   // last original prediction result
-let _predictAugResult  = null;   // last augmented prediction result
-let _predictOrigKey    = null;   // "run::filename::size" — cache key for orig result
+let _inferRuns       = [];
+let _inferAugSchema  = [];
+let _inferFile       = null;   // File object from drop / browse
+let _inferAugments   = [];     // [{id, name, label, params: {name: value}}]
+let _inferAugCounter = 0;
+let _inferOrigResult = null;   // last original prediction result
+let _inferAugResult  = null;   // last augmented prediction result
+let _inferOrigKey    = null;   // "run::filename::size" — cache key for orig result
 
-async function showPredict() {
-  setActive('nav-predict');
+async function showInference() {
+  setActive('nav-inference');
   const page = document.getElementById('page');
   page.innerHTML = '<p aria-busy="true">Loading…</p>';
 
   try {
-    [_predictRuns, _predictAugSchema] = await Promise.all([
+    [_inferRuns, _inferAugSchema] = await Promise.all([
       api('/runs'),
       api('/augmentations'),
     ]);
@@ -639,40 +639,40 @@ async function showPredict() {
     return;
   }
 
-  _predictFile       = null;
-  _predictAugments   = [];
-  _predictAugCounter = 0;
-  _predictOrigResult = null;
-  _predictAugResult  = null;
+  _inferFile       = null;
+  _inferAugments   = [];
+  _inferAugCounter = 0;
+  _inferOrigResult = null;
+  _inferAugResult  = null;
 
-  page.innerHTML = buildPredictPage();
+  page.innerHTML = buildInferencePage();
   _initDropZone();
 }
 
-function buildPredictPage() {
-  const runOptions = _predictRuns.length
-    ? _predictRuns.map(r =>
+function buildInferencePage() {
+  const runOptions = _inferRuns.length
+    ? _inferRuns.map(r =>
         `<option value="${escHtml(r.name)}">${escHtml(r.name)} (${escHtml(r.backbone)}, ${fmtAcc(r.val_accuracy)})</option>`
       ).join('')
     : '<option value="">No runs available</option>';
 
   return `
-    <div class="page-header"><h2>Predict</h2></div>
-    <div class="predict-layout">
+    <div class="page-header"><h2>Inference</h2></div>
+    <div class="inference-layout">
 
       <!-- LEFT PANEL -->
-      <div class="predict-left">
+      <div class="inference-left">
 
-        <div class="predict-section">
+        <div class="inference-section">
           <p class="section-label">Model</p>
-          <select id="predict-run-select" style="margin:0">
+          <select id="inference-run-select" style="margin:0">
             ${runOptions}
           </select>
         </div>
 
-        <div class="predict-section">
+        <div class="inference-section">
           <p class="section-label">Image</p>
-          <div class="drop-zone" id="predict-drop-zone" onclick="document.getElementById('predict-file-input').click()">
+          <div class="drop-zone" id="inference-drop-zone" onclick="document.getElementById('inference-file-input').click()">
             <div class="drop-inner" id="drop-inner">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
@@ -681,18 +681,18 @@ function buildPredictPage() {
               </svg>
               <span>Drop image or click to browse</span>
             </div>
-            <input type="file" id="predict-file-input" accept="image/*" style="display:none"
-                   onchange="onPredictFileSelected(this.files[0])">
+            <input type="file" id="inference-file-input" accept="image/*" style="display:none"
+                   onchange="onInferFileSelected(this.files[0])">
           </div>
         </div>
 
-        <div class="predict-section">
-          <div class="predict-aug-header">
+        <div class="inference-section">
+          <div class="inference-aug-header">
             <p class="section-label" style="margin:0">Augmentations</p>
             <div style="position:relative">
-              <button class="predict-add-btn outline" onclick="toggleAugDropdown(event)">+ Add</button>
+              <button class="inference-add-btn outline" onclick="toggleAugDropdown(event)">+ Add</button>
               <div class="aug-dropdown" id="aug-dropdown" style="display:none">
-                ${_predictAugSchema.map(a =>
+                ${_inferAugSchema.map(a =>
                   `<div class="aug-dropdown-item" onclick="addAugmentation('${escHtml(a.name)}')">${escHtml(a.label)}</div>`
                 ).join('')}
               </div>
@@ -701,15 +701,15 @@ function buildPredictPage() {
           <div id="aug-stack"></div>
         </div>
 
-        <button id="predict-run-btn" class="predict-run-btn" onclick="runPrediction()" disabled>
+        <button id="inference-run-btn" class="inference-run-btn" onclick="runInference()" disabled>
           ▶ Run
         </button>
 
       </div>
 
       <!-- RIGHT PANEL -->
-      <div class="predict-right" id="predict-right">
-        <div class="predict-placeholder">
+      <div class="inference-right" id="inference-right">
+        <div class="inference-placeholder">
           <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" opacity="0.3" aria-hidden="true">
             <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>
             <polyline points="21 15 16 10 5 21"/>
@@ -725,7 +725,7 @@ function buildPredictPage() {
 /* ── Drop zone ─────────────────────────────────────────────────────────────── */
 
 function _initDropZone() {
-  const zone = document.getElementById('predict-drop-zone');
+  const zone = document.getElementById('inference-drop-zone');
   if (!zone) return;
 
   zone.addEventListener('dragover', e => { e.preventDefault(); zone.classList.add('drag-over'); });
@@ -734,13 +734,13 @@ function _initDropZone() {
     e.preventDefault();
     zone.classList.remove('drag-over');
     const f = e.dataTransfer.files[0];
-    if (f) onPredictFileSelected(f);
+    if (f) onInferFileSelected(f);
   });
 }
 
-function onPredictFileSelected(file) {
+function onInferFileSelected(file) {
   if (!file) return;
-  _predictFile = file;
+  _inferFile = file;
 
   const reader = new FileReader();
   reader.onload = ev => {
@@ -752,13 +752,13 @@ function onPredictFileSelected(file) {
   };
   reader.readAsDataURL(file);
 
-  const btn = document.getElementById('predict-run-btn');
+  const btn = document.getElementById('inference-run-btn');
   if (btn) btn.disabled = false;
 
   // Clear previous results — new file invalidates the orig cache
-  _predictOrigResult = null;
-  _predictAugResult  = null;
-  _predictOrigKey    = null;
+  _inferOrigResult = null;
+  _inferAugResult  = null;
+  _inferOrigKey    = null;
   _renderRight();
 }
 
@@ -774,25 +774,25 @@ function toggleAugDropdown(e) {
 }
 
 function addAugmentation(name) {
-  const schema = _predictAugSchema.find(a => a.name === name);
+  const schema = _inferAugSchema.find(a => a.name === name);
   if (!schema) return;
 
-  const id = ++_predictAugCounter;
+  const id = ++_inferAugCounter;
   const params = {};
   schema.params.forEach(p => { params[p.name] = p.default; });
-  _predictAugments.push({ id, name, label: schema.label, params });
+  _inferAugments.push({ id, name, label: schema.label, params });
   _renderAugStack();
 }
 
 function removeAugmentation(id) {
-  _predictAugments = _predictAugments.filter(a => a.id !== id);
+  _inferAugments = _inferAugments.filter(a => a.id !== id);
   _renderAugStack();
 }
 
 function updateAugParam(id, paramName, value) {
-  const aug = _predictAugments.find(a => a.id === id);
+  const aug = _inferAugments.find(a => a.id === id);
   if (!aug) return;
-  const schema = _predictAugSchema.find(a => a.name === aug.name);
+  const schema = _inferAugSchema.find(a => a.name === aug.name);
   const pSchema = schema?.params.find(p => p.name === paramName);
   aug.params[paramName] = pSchema?.type === 'int' ? parseInt(value, 10) : pSchema?.type === 'float' ? parseFloat(value) : value;
   // Update displayed value label without full re-render
@@ -804,13 +804,13 @@ function _renderAugStack() {
   const stack = document.getElementById('aug-stack');
   if (!stack) return;
 
-  if (_predictAugments.length === 0) {
+  if (_inferAugments.length === 0) {
     stack.innerHTML = '<p class="aug-empty">No augmentations added.</p>';
     return;
   }
 
-  stack.innerHTML = _predictAugments.map(aug => {
-    const schema = _predictAugSchema.find(a => a.name === aug.name);
+  stack.innerHTML = _inferAugments.map(aug => {
+    const schema = _inferAugSchema.find(a => a.name === aug.name);
     const controls = (schema?.params || []).map(p => {
       const val = aug.params[p.name];
       if (p.type === 'choice') {
@@ -850,27 +850,27 @@ function _renderAugStack() {
 
 /* ── Run prediction ────────────────────────────────────────────────────────── */
 
-async function runPrediction() {
-  if (!_predictFile) return;
+async function runInference() {
+  if (!_inferFile) return;
 
-  const run = document.getElementById('predict-run-select')?.value;
+  const run = document.getElementById('inference-run-select')?.value;
   if (!run) return;
 
-  const btn = document.getElementById('predict-run-btn');
+  const btn = document.getElementById('inference-run-btn');
   if (btn) { btn.disabled = true; btn.textContent = '…'; }
 
-  const hasAug = _predictAugments.length > 0;
-  const origKey = `${run}::${_predictFile.name}::${_predictFile.size}`;
-  const origCached = _predictOrigResult && _predictOrigKey === origKey;
+  const hasAug = _inferAugments.length > 0;
+  const origKey = `${run}::${_inferFile.name}::${_inferFile.size}`;
+  const origCached = _inferOrigResult && _inferOrigKey === origKey;
 
-  _predictAugResult = null;
+  _inferAugResult = null;
   _renderPendingGrid(hasAug, origCached);
 
   try {
     if (!origCached) {
-      _predictOrigResult = null;
+      _inferOrigResult = null;
       const fd = new FormData();
-      fd.append('file', _predictFile);
+      fd.append('file', _inferFile);
       fd.append('run', run);
 
       const origRes = await fetch('/api/predict/single', { method: 'POST', body: fd });
@@ -878,15 +878,15 @@ async function runPrediction() {
         const err = await origRes.json().catch(() => ({ detail: origRes.statusText }));
         throw new Error(err.detail || origRes.statusText);
       }
-      _predictOrigResult = await origRes.json();
-      _predictOrigKey    = origKey;
+      _inferOrigResult = await origRes.json();
+      _inferOrigKey    = origKey;
       _updateOrigPanel();
     }
 
     if (hasAug) {
-      const augPayload = _predictAugments.map(a => ({ name: a.name, params: a.params }));
+      const augPayload = _inferAugments.map(a => ({ name: a.name, params: a.params }));
       const fd2 = new FormData();
-      fd2.append('file', _predictFile);
+      fd2.append('file', _inferFile);
       fd2.append('run', run);
       fd2.append('augmentations', JSON.stringify(augPayload));
 
@@ -895,11 +895,11 @@ async function runPrediction() {
         const err = await augRes.json().catch(() => ({ detail: augRes.statusText }));
         throw new Error(err.detail || augRes.statusText);
       }
-      _predictAugResult = await augRes.json();
+      _inferAugResult = await augRes.json();
       _updateAugPanel();
     }
   } catch (e) {
-    document.getElementById('predict-right').innerHTML =
+    document.getElementById('inference-right').innerHTML =
       `<p class="error-msg">${escHtml(e.message)}</p>`;
     if (btn) { btn.disabled = false; btn.textContent = '▶ Run'; }
     return;
@@ -911,17 +911,17 @@ async function runPrediction() {
 /* ── Right panel rendering ─────────────────────────────────────────────────── */
 
 function _renderRight() {
-  const right = document.getElementById('predict-right');
+  const right = document.getElementById('inference-right');
   if (!right) return;
   right.innerHTML = `
-    <div class="predict-placeholder">
+    <div class="inference-placeholder">
       <p>Drop an image and press Run to see predictions</p>
     </div>`;
 }
 
 function _pendingSlot(label) {
   return `
-    <div class="predict-result-panel">
+    <div class="inference-result-panel">
       <p class="section-label">${label}</p>
       <div class="aug-processing-placeholder">
         <div class="aug-processing-spinner"></div>
@@ -931,42 +931,42 @@ function _pendingSlot(label) {
 }
 
 function _renderPendingGrid(hasAug, origCached) {
-  const right = document.getElementById('predict-right');
+  const right = document.getElementById('inference-right');
   if (!right) return;
   const origContent = origCached
-    ? `<div class="predict-result-panel"><p class="section-label">Original</p>${buildResultPanel('orig', _predictOrigResult, null)}</div>`
+    ? `<div class="inference-result-panel"><p class="section-label">Original</p>${buildResultPanel('orig', _inferOrigResult, null)}</div>`
     : _pendingSlot('Original');
   right.innerHTML = `
-    <div class="predict-results-grid ${hasAug ? 'has-aug' : ''}">
-      <div id="predict-orig-slot">${origContent}</div>
-      ${hasAug ? `<div id="predict-aug-slot">${_pendingSlot('Augmented')}</div>` : '<div id="predict-aug-slot"></div>'}
+    <div class="inference-results-grid ${hasAug ? 'has-aug' : ''}">
+      <div id="inference-orig-slot">${origContent}</div>
+      ${hasAug ? `<div id="inference-aug-slot">${_pendingSlot('Augmented')}</div>` : '<div id="inference-aug-slot"></div>'}
     </div>`;
 }
 
 function _updateOrigPanel() {
-  const slot = document.getElementById('predict-orig-slot');
-  if (!slot || !_predictOrigResult) return;
+  const slot = document.getElementById('inference-orig-slot');
+  if (!slot || !_inferOrigResult) return;
   slot.innerHTML = `
-    <div class="predict-result-panel">
+    <div class="inference-result-panel">
       <p class="section-label">Original</p>
-      ${buildResultPanel('orig', _predictOrigResult, null)}
+      ${buildResultPanel('orig', _inferOrigResult, null)}
     </div>`;
 }
 
 function _updateAugPanel() {
-  if (!_predictAugResult) return;
-  const grid = document.querySelector('.predict-results-grid');
+  if (!_inferAugResult) return;
+  const grid = document.querySelector('.inference-results-grid');
   if (grid) grid.classList.add('has-aug');
-  const flipped = _predictAugResult.class_name !== _predictOrigResult.class_name;
-  const slot = document.getElementById('predict-aug-slot');
+  const flipped = _inferAugResult.class_name !== _inferOrigResult.class_name;
+  const slot = document.getElementById('inference-aug-slot');
   if (!slot) return;
   slot.innerHTML = `
-    <div class="predict-result-panel ${flipped ? 'result-flipped' : ''}">
+    <div class="inference-result-panel ${flipped ? 'result-flipped' : ''}">
       <p class="section-label">
         Augmented
         ${flipped ? '<span class="flip-badge">⚠ prediction changed</span>' : ''}
       </p>
-      ${buildResultPanel('aug', _predictAugResult, _predictAugResult.augmented_image_b64)}
+      ${buildResultPanel('aug', _inferAugResult, _inferAugResult.augmented_image_b64)}
     </div>`;
 }
 
@@ -990,7 +990,7 @@ function buildResultPanel(panelId, result, augImageB64) {
 
   const imgSrc = augImageB64
     ? `data:image/png;base64,${augImageB64}`
-    : (_predictFile ? URL.createObjectURL(_predictFile) : '');
+    : (_inferFile ? URL.createObjectURL(_inferFile) : '');
 
   return `
     <div class="result-image-wrap">
@@ -1008,7 +1008,7 @@ function buildResultPanel(panelId, result, augImageB64) {
   `;
 }
 
-/* ── XAI for predict page ──────────────────────────────────────────────────── */
+/* ── XAI for inference page ─────────────────────────────────────────────────── */
 
 async function explainPrediction(event, panelId, classIndex) {
   const btn = event.target;
@@ -1037,13 +1037,13 @@ async function explainPrediction(event, panelId, classIndex) {
   btn.disabled = true;
   if (errEl) errEl.textContent = '';
 
-  const run = document.getElementById('predict-run-select')?.value;
+  const run = document.getElementById('inference-run-select')?.value;
   if (!run) { btn.textContent = 'Explain'; btn.disabled = false; return; }
 
   // For the augmented panel, XAI runs on the augmented image bytes (base64 → Blob)
-  let fileToSend = _predictFile;
-  if (panelId === 'aug' && _predictAugResult?.augmented_image_b64) {
-    const binary = atob(_predictAugResult.augmented_image_b64);
+  let fileToSend = _inferFile;
+  if (panelId === 'aug' && _inferAugResult?.augmented_image_b64) {
+    const binary = atob(_inferAugResult.augmented_image_b64);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
     fileToSend = new Blob([bytes], { type: 'image/png' });


### PR DESCRIPTION
## Summary

- Renamed the **Predict** nav item to **Inference** (`#/predict` → `#/inference`)
- Updated all related JS identifiers: route handler, functions (`showInference`, `buildInferencePage`, `runInference`, `onInferFileSelected`), state variables (`_infer*`), and DOM IDs (`inference-run-select`, `inference-drop-zone`, etc.)
- Updated CSS class names in `style.css` to match (`inference-layout`, `inference-left`, `inference-right`, etc.)
- Model-output terminology (`predicted_class`, `Predicted →`, `/api/predict/*` endpoints) left unchanged

## Test plan

- [x] Navigate to Inference page via sidebar — link is active and page loads correctly
- [x] Drop an image and run — original result panel appears
- [x] Add an augmentation and run — side-by-side grid renders correctly
- [x] GradCAM explain button works on both panels